### PR TITLE
Changes for CentOS

### DIFF
--- a/ansible/roles/common/vars/main.yml
+++ b/ansible/roles/common/vars/main.yml
@@ -12,7 +12,7 @@ file_descriptor_limit: 65536
 vagrant_dirs:
   'windows': c:\vagrant
   'linux': /vagranelastic_pkgt
-current_host_ip: "{{ hostvars[inventory_hostname]['ansible_eth0']['ipv4']['address'] }}"
+current_host_ip: "{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}"
 install_dirs:
   'tar.gz': '/tmp'
   'zip':    'c:\temp'

--- a/ansible/roles/elasticsearch/tasks/linux/elasticsearch_api_get_info.yml
+++ b/ansible/roles/elasticsearch/tasks/linux/elasticsearch_api_get_info.yml
@@ -13,7 +13,7 @@
   block:
     - name: Elasticsearch HTTP GET ?pretty
       uri:
-        url: "http://{{ hostvars[inventory_hostname]['ansible_eth0']['ipv4']['address'] }}:{{ elasticsearch_port }}/?pretty"
+        url: "http://{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}:{{ elasticsearch_port }}/?pretty"
         method: GET
         return_content: yes
         status_code: 200
@@ -26,7 +26,7 @@
   block:
     - name: Elasticsearch HTTPS GET ?pretty
       uri:
-        url: "https://{{ hostvars[inventory_hostname]['ansible_eth0']['ipv4']['address'] }}:{{ elasticsearch_port }}/?pretty"
+        url: "https://{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}:{{ elasticsearch_port }}/?pretty"
         method: GET
         user: "{{ elasticsearch_username }}"
         password: "{{ elasticsearch_password }}"

--- a/ansible/roles/xpack_auditbeat/vars/main.yml
+++ b/ansible/roles/xpack_auditbeat/vars/main.yml
@@ -13,7 +13,7 @@ xpack_auditbeat_roles:
   xpack_auditbeat_install_config_start_verify:
     - { action: 'auditbeat_install', parent: 'auditbeat', args: {} }
     - { action: 'xpack_auditbeat_config',  parent: '', args: {} }
-    - { action: 'auditbeat_restart',  parent: 'auditbeat', args: {} }
+    - { action: 'auditbeat_startup',  parent: 'auditbeat', args: {} }
     - { action: 'auditbeat_is_running', parent: 'auditbeat', args: {} }
   xpack_auditbeat_rmconfig_start_verify:
     - { action: 'xpack_auditbeat_config_remove', parent: '', args: {} }

--- a/ansible/roles/xpack_elasticsearch/tasks/linux/xpack_elasticsearch_config.yml
+++ b/ansible/roles/xpack_elasticsearch/tasks/linux/xpack_elasticsearch_config.yml
@@ -11,7 +11,7 @@
     marker: '# {mark} ANSIBLE MANAGED BLOCK ELASTICSEARCH XPACK PARAMETERS'
     insertafter: EOF
     content: |
-      network.host: {{ hostvars[inventory_hostname]['ansible_eth0']['ipv4']['address'] }}
+      network.host: {{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}
       xpack.security.http.ssl.enabled: true
       xpack.ssl.key: {{ elasticsearch_xpack_config_dir }}/node/node.key
       xpack.ssl.certificate: {{ elasticsearch_xpack_config_dir }}/node/node.crt

--- a/ansible/roles/xpack_elasticsearch/tasks/linux/xpack_elasticsearch_create_users_roles.yml
+++ b/ansible/roles/xpack_elasticsearch/tasks/linux/xpack_elasticsearch_create_users_roles.yml
@@ -8,7 +8,7 @@
 
 - name: Add Users and Roles
   uri:
-    url: "https://{{ hostvars[inventory_hostname]['ansible_eth0']['ipv4']['address'] }}:{{ elasticsearch_port }}/_xpack/security/{{ role_user.path }}"
+    url: "https://{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}:{{ elasticsearch_port }}/_xpack/security/{{ role_user.path }}"
     method: POST
     user: "{{ elasticsearch_username }}"
     password: "{{ elasticsearch_password }}"

--- a/ansible/roles/xpack_elasticsearch/tasks/linux/xpack_elasticsearch_set_passwords.yml
+++ b/ansible/roles/xpack_elasticsearch/tasks/linux/xpack_elasticsearch_set_passwords.yml
@@ -43,7 +43,7 @@
 
 - name: Set elastic password
   uri:
-    url: "https://{{ hostvars[inventory_hostname]['ansible_eth0']['ipv4']['address'] }}:{{ elasticsearch_port }}/_xpack/security/user/elastic/_password?pretty"
+    url: "https://{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}:{{ elasticsearch_port }}/_xpack/security/user/elastic/_password?pretty"
     method: POST
     user: "{{ elasticsearch_username }}"
     password: "{{ initial_elasticsearch_password }}"
@@ -55,7 +55,7 @@
 
 - name: Set kibana password
   uri:
-    url: "https://{{ hostvars[inventory_hostname]['ansible_eth0']['ipv4']['address'] }}:{{ elasticsearch_port }}/_xpack/security/user/kibana/_password?pretty"
+    url: "https://{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}:{{ elasticsearch_port }}/_xpack/security/user/kibana/_password?pretty"
     method: POST
     user: "{{ kibana_username }}"
     password: "{{ initial_kibana_password }}"
@@ -67,7 +67,7 @@
 
 - name: Set logstash_system password
   uri:
-    url: "https://{{ hostvars[inventory_hostname]['ansible_eth0']['ipv4']['address'] }}:{{ elasticsearch_port }}/_xpack/security/user/logstash_system/_password?pretty"
+    url: "https://{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}:{{ elasticsearch_port }}/_xpack/security/user/logstash_system/_password?pretty"
     method: POST
     user: "{{ logstash_username }}"
     password: "{{ initial_logstash_password }}"

--- a/ansible/roles/xpack_elasticsearch/vars/main.yml
+++ b/ansible/roles/xpack_elasticsearch/vars/main.yml
@@ -16,7 +16,7 @@ xpack_elasticsearch_roles:
     - { action: 'xpack_elasticsearch_install', parent: '', args: {} }
     - { action: 'xpack_elasticsearch_certs',   parent: '', args: {} }
     - { action: 'xpack_elasticsearch_config',  parent: '', args: {} }
-    - { action: 'elasticsearch_restart',  parent: 'elasticsearch', args: {} }
+    - { action: 'elasticsearch_startup',  parent: 'elasticsearch', args: {} }
     - { action: 'elasticsearch_log_tail', parent: 'elasticsearch', args: {ait_log_searchstr: started} }
     - { action: 'elasticsearch_is_running', parent: 'elasticsearch', args: {} }
     - { action: 'xpack_elasticsearch_set_passwords',  parent: '', args: {} }
@@ -26,7 +26,7 @@ xpack_elasticsearch_roles:
     - { action: 'xpack_elasticsearch_certs',   parent: '', args: {} }
     - { action: 'elasticsearch_config_remove', parent: 'elasticsearch', args: {} }
     - { action: 'xpack_elasticsearch_config',  parent: '', args: {} }
-    - { action: 'elasticsearch_restart',  parent: 'elasticsearch', args: {} }
+    - { action: 'elasticsearch_startup',  parent: 'elasticsearch', args: {} }
     - { action: 'elasticsearch_log_tail', parent: 'elasticsearch', args: {ait_log_searchstr: started} }
     - { action: 'elasticsearch_is_running', parent: 'elasticsearch', args: {} }
     - { action: 'xpack_elasticsearch_set_passwords',  parent: '', args: {} }
@@ -36,7 +36,7 @@ xpack_elasticsearch_roles:
     - { action: 'xpack_elasticsearch_install', parent: '', args: {} }
     - { action: 'xpack_elasticsearch_certs',   parent: '', args: {} }
     - { action: 'xpack_elasticsearch_config',  parent: '', args: {} }
-    - { action: 'elasticsearch_restart',  parent: 'elasticsearch', args: {} }
+    - { action: 'elasticsearch_startup',  parent: 'elasticsearch', args: {} }
     - { action: 'elasticsearch_log_tail', parent: 'elasticsearch', args: {ait_log_searchstr: started} }
     - { action: 'elasticsearch_is_running', parent: 'elasticsearch', args: {} }
     - { action: 'xpack_elasticsearch_set_passwords',  parent: '', args: {} }
@@ -47,7 +47,7 @@ xpack_elasticsearch_roles:
     - { action: 'xpack_elasticsearch_certs',   parent: '', args: {} }
     - { action: 'elasticsearch_config_remove', parent: 'elasticsearch', args: {} }
     - { action: 'xpack_elasticsearch_config',  parent: '', args: {} }
-    - { action: 'elasticsearch_restart',  parent: 'elasticsearch', args: {} }
+    - { action: 'elasticsearch_startup',  parent: 'elasticsearch', args: {} }
     - { action: 'elasticsearch_log_tail', parent: 'elasticsearch', args: {ait_log_searchstr: started} }
     - { action: 'elasticsearch_is_running', parent: 'elasticsearch', args: {} }
     - { action: 'xpack_elasticsearch_set_passwords',  parent: '', args: {} }
@@ -56,7 +56,7 @@ xpack_elasticsearch_roles:
   xpack_elasticsearch_plugin_rmconfig_uninstall_start_verify:
     - { action: 'xpack_elasticsearch_config_remove', parent: '', args: {} }
     - { action: 'xpack_elasticsearch_uninstall', parent: '', args: {} }
-    - { action: 'elasticsearch_restart',  parent: 'elasticsearch', args: {} }
+    - { action: 'elasticsearch_startup',  parent: 'elasticsearch', args: {} }
     - { action: 'elasticsearch_log_tail', parent: 'elasticsearch', args: {ait_log_searchstr: started} }
     - { action: 'elasticsearch_is_running', parent: 'elasticsearch', args: {} }
     - { action: 'elasticsearch_api_get_info', parent: 'elasticsearch', args: {} }

--- a/ansible/roles/xpack_filebeat/vars/main.yml
+++ b/ansible/roles/xpack_filebeat/vars/main.yml
@@ -13,26 +13,26 @@ xpack_filebeat_roles:
   xpack_filebeat_install_config_start_verify:
     - { action: 'filebeat_install', parent: 'filebeat', args: {} }
     - { action: 'xpack_filebeat_config',  parent: '', args: {} }
-    - { action: 'filebeat_restart',  parent: 'filebeat', args: {} }
+    - { action: 'filebeat_startup',  parent: 'filebeat', args: {} }
     - { action: 'filebeat_is_running', parent: 'filebeat', args: {} }
   xpack_filebeat_config_start_verify:
     - { action: 'xpack_filebeat_config',  parent: '', args: {} }
-    - { action: 'filebeat_restart',  parent: 'filebeat', args: {} }
+    - { action: 'filebeat_startup',  parent: 'filebeat', args: {} }
     - { action: 'filebeat_is_running', parent: 'filebeat', args: {} }
   xpack_filebeat_install_config_start_verify_import_dashboards:
     - { action: 'filebeat_install', parent: 'filebeat', args: {} }
     - { action: 'xpack_filebeat_config',  parent: '', args: {} }
-    - { action: 'filebeat_restart',  parent: 'filebeat', args: {} }
+    - { action: 'filebeat_startup',  parent: 'filebeat', args: {} }
     - { action: 'filebeat_is_running', parent: 'filebeat', args: {} }
     - { action: 'filebeat_import_dashboards', parent: 'filebeat', args: {} }
   xpack_filebeat_config_start_verify_import_dashboards:
     - { action: 'xpack_filebeat_config',  parent: '', args: {} }
-    - { action: 'filebeat_restart',  parent: 'filebeat', args: {} }
+    - { action: 'filebeat_startup',  parent: 'filebeat', args: {} }
     - { action: 'filebeat_is_running', parent: 'filebeat', args: {} }
     - { action: 'filebeat_import_dashboards', parent: 'filebeat', args: {} }
   xpack_filebeat_rmconfig_start_verify:
     - { action: 'xpack_filebeat_config_remove', parent: '', args: {} }
-    - { action: 'filebeat_restart',  parent: 'filebeat', args: {} }
+    - { action: 'filebeat_startup',  parent: 'filebeat', args: {} }
     - { action: 'filebeat_is_running', parent: 'filebeat', args: {} }
 
 # Task files for group use, keep in sync with tasks/main.yml except for parent tasks

--- a/ansible/roles/xpack_heartbeat/vars/main.yml
+++ b/ansible/roles/xpack_heartbeat/vars/main.yml
@@ -13,11 +13,11 @@ xpack_heartbeat_roles:
   xpack_heartbeat_install_config_start_verify:
     - { action: 'heartbeat_install', parent: 'heartbeat', args: {} }
     - { action: 'xpack_heartbeat_config',  parent: '', args: {} }
-    - { action: 'heartbeat_restart',  parent: 'heartbeat', args: {} }
+    - { action: 'heartbeat_startup',  parent: 'heartbeat', args: {} }
     - { action: 'heartbeat_is_running', parent: 'heartbeat', args: {} }
   xpack_heartbeat_rmconfig_start_verify:
     - { action: 'xpack_heartbeat_config_remove', parent: '', args: {} }
-    - { action: 'heartbeat_restart',  parent: 'heartbeat', args: {} }
+    - { action: 'heartbeat_startup',  parent: 'heartbeat', args: {} }
     - { action: 'heartbeat_is_running', parent: 'heartbeat', args: {} }
 
 # Task files for group use, keep in sync with tasks/main.yml except for parent tasks

--- a/ansible/roles/xpack_kibana/tasks/linux/xpack_kibana_config.yml
+++ b/ansible/roles/xpack_kibana/tasks/linux/xpack_kibana_config.yml
@@ -31,7 +31,7 @@
     marker: '# {mark} ANSIBLE MANAGED BLOCK KIBANA XPACK PARAMETERS'
     insertafter: EOF
     content: |
-      elasticsearch.url: "https://{{ hostvars[inventory_hostname]['ansible_eth0']['ipv4']['address'] }}:{{ elasticsearch_port }}"
+      elasticsearch.url: "https://{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}:{{ elasticsearch_port }}"
       elasticsearch.username: {{ elasticsearch_username }}
       elasticsearch.password: {{ elasticsearch_password }}
       server.ssl.enabled: true

--- a/ansible/roles/xpack_kibana/vars/main.yml
+++ b/ansible/roles/xpack_kibana/vars/main.yml
@@ -16,19 +16,19 @@ xpack_kibana_roles:
     - { action: 'xpack_kibana_install', parent: '', args: {} }
     - { action: 'kibana_config',  parent: 'kibana', args: {} }
     - { action: 'xpack_kibana_config',  parent: '', args: {} }
-    - { action: 'kibana_restart',  parent: 'kibana', args: {} }
+    - { action: 'kibana_startup',  parent: 'kibana', args: {} }
     - { action: 'kibana_log_tail', parent: 'kibana', args: {ait_log_searchstr: started} }
     - { action: 'kibana_is_running', parent: 'kibana', args: {} }
   xpack_kibana_plugin_config_start_verify:
     - { action: 'xpack_kibana_install', parent: '', args: {} }
     - { action: 'xpack_kibana_config',  parent: '', args: {} }
-    - { action: 'kibana_restart',  parent: 'kibana', args: {} }
+    - { action: 'kibana_startup',  parent: 'kibana', args: {} }
     - { action: 'kibana_log_tail', parent: 'kibana', args: {ait_log_searchstr: started} }
     - { action: 'kibana_is_running', parent: 'kibana', args: {} }
   xpack_kibana_plugin_rmconfig_uninstall_start_verify:
     - { action: 'xpack_kibana_config_remove', parent: '', args: {} }
     - { action: 'xpack_kibana_uninstall', parent: '', args: {} }
-    - { action: 'kibana_restart',  parent: 'kibana', args: {} }
+    - { action: 'kibana_startup',  parent: 'kibana', args: {} }
     - { action: 'kibana_log_tail', parent: 'kibana', args: {ait_log_searchstr: started} }
     - { action: 'kibana_is_running', parent: 'kibana', args: {} }
 

--- a/ansible/roles/xpack_logstash/tasks/linux/xpack_logstash_config.yml
+++ b/ansible/roles/xpack_logstash/tasks/linux/xpack_logstash_config.yml
@@ -31,7 +31,7 @@
     marker: '# {mark} ANSIBLE MANAGED BLOCK LOGSTASH XPACK PARAMETERS'
     insertafter: EOF
     content: |
-      xpack.monitoring.elasticsearch.url: https://{{ hostvars[inventory_hostname]['ansible_eth0']['ipv4']['address'] }}:{{ elasticsearch_port }}
+      xpack.monitoring.elasticsearch.url: https://{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}:{{ elasticsearch_port }}
       xpack.monitoring.elasticsearch.username: {{ elasticsearch_username }}
       xpack.monitoring.elasticsearch.password: {{ elasticsearch_password }}
       xpack.monitoring.elasticsearch.ssl.ca: {{ logstash_rootdir | trim }}/ca/ca.crt

--- a/ansible/roles/xpack_logstash/vars/main.yml
+++ b/ansible/roles/xpack_logstash/vars/main.yml
@@ -30,14 +30,14 @@ xpack_logstash_roles:
     - { action: 'xpack_logstash_install', parent: '', args: {} }
     - { action: 'xpack_logstash_config',  parent: '', args: {} }
     - { action: 'logstash_conf', parent: 'logstash', args: { ait_logstash_conf_xpack: "{{ xpack_logstash_conf_params }}" } }
-    - { action: 'logstash_restart',  parent: 'logstash', args: {} }
+    - { action: 'logstash_startup',  parent: 'logstash', args: {} }
     - { action: 'logstash_log_tail', parent: 'logstash', args: {ait_log_searchstr: started} }
     - { action: 'logstash_is_running', parent: 'logstash', args: {} }
   xpack_logstash_rmconfig_uninstall_start_verify:
     - { action: 'xpack_logstash_config_remove', parent: '', args: {} }
     - { action: 'xpack_logstash_uninstall', parent: '', args: {} }
     - { action: 'logstash_conf', parent: 'logstash', args: {} }
-    - { action: 'logstash_restart',  parent: 'logstash', args: {} }
+    - { action: 'logstash_startup',  parent: 'logstash', args: {} }
     - { action: 'logstash_log_tail', parent: 'logstash', args: {ait_log_searchstr: started} }
     - { action: 'logstash_is_running', parent: 'logstash', args: {} }
 

--- a/ansible/roles/xpack_metricbeat/vars/main.yml
+++ b/ansible/roles/xpack_metricbeat/vars/main.yml
@@ -13,26 +13,26 @@ xpack_metricbeat_roles:
   xpack_metricbeat_install_config_start_verify:
     - { action: 'metricbeat_install', parent: 'metricbeat', args: {} }
     - { action: 'xpack_metricbeat_config',  parent: '', args: {} }
-    - { action: 'metricbeat_restart',  parent: 'metricbeat', args: {} }
+    - { action: 'metricbeat_startup',  parent: 'metricbeat', args: {} }
     - { action: 'metricbeat_is_running', parent: 'metricbeat', args: {} }
   xpack_metricbeat_config_start_verify:
     - { action: 'xpack_metricbeat_config',  parent: '', args: {} }
-    - { action: 'metricbeat_restart',  parent: 'metricbeat', args: {} }
+    - { action: 'metricbeat_startup',  parent: 'metricbeat', args: {} }
     - { action: 'metricbeat_is_running', parent: 'metricbeat', args: {} }
   xpack_metricbeat_install_config_start_verify_import_dashboards:
     - { action: 'metricbeat_install', parent: 'metricbeat', args: {} }
     - { action: 'xpack_metricbeat_config',  parent: '', args: {} }
-    - { action: 'metricbeat_restart',  parent: 'metricbeat', args: {} }
+    - { action: 'metricbeat_startup',  parent: 'metricbeat', args: {} }
     - { action: 'metricbeat_is_running', parent: 'metricbeat', args: {} }
     - { action: 'metricbeat_import_dashboards', parent: 'metricbeat', args: {} }
   xpack_metricbeat_config_start_verify_import_dashboards:
     - { action: 'xpack_metricbeat_config',  parent: '', args: {} }
-    - { action: 'metricbeat_restart',  parent: 'metricbeat', args: {} }
+    - { action: 'metricbeat_startup',  parent: 'metricbeat', args: {} }
     - { action: 'metricbeat_is_running', parent: 'metricbeat', args: {} }
     - { action: 'metricbeat_import_dashboards', parent: 'metricbeat', args: {} }
   xpack_metricbeat_rmconfig_start_verify:
     - { action: 'xpack_metricbeat_config_remove', parent: '', args: {} }
-    - { action: 'metricbeat_restart',  parent: 'metricbeat', args: {} }
+    - { action: 'metricbeat_startup',  parent: 'metricbeat', args: {} }
     - { action: 'metricbeat_is_running', parent: 'metricbeat', args: {} }
 
 # Task files for group use, keep in sync with tasks/main.yml except for parent tasks

--- a/ansible/roles/xpack_packetbeat/vars/main.yml
+++ b/ansible/roles/xpack_packetbeat/vars/main.yml
@@ -13,26 +13,26 @@ xpack_packetbeat_roles:
   xpack_packetbeat_install_config_start_verify:
     - { action: 'packetbeat_install', parent: 'packetbeat', args: {} }
     - { action: 'xpack_packetbeat_config',  parent: '', args: {} }
-    - { action: 'packetbeat_restart',  parent: 'packetbeat', args: {} }
+    - { action: 'packetbeat_startup',  parent: 'packetbeat', args: {} }
     - { action: 'packetbeat_is_running', parent: 'packetbeat', args: {} }
   xpack_packetbeat_config_start_verify:
     - { action: 'xpack_packetbeat_config',  parent: '', args: {} }
-    - { action: 'packetbeat_restart',  parent: 'packetbeat', args: {} }
+    - { action: 'packetbeat_startup',  parent: 'packetbeat', args: {} }
     - { action: 'packetbeat_is_running', parent: 'packetbeat', args: {} }
   xpack_packetbeat_install_config_start_verify_import_dashboards:
     - { action: 'packetbeat_install', parent: 'packetbeat', args: {} }
     - { action: 'xpack_packetbeat_config',  parent: '', args: {} }
-    - { action: 'packetbeat_restart',  parent: 'packetbeat', args: {} }
+    - { action: 'packetbeat_startup',  parent: 'packetbeat', args: {} }
     - { action: 'packetbeat_is_running', parent: 'packetbeat', args: {} }
     - { action: 'packetbeat_import_dashboards', parent: 'packetbeat', args: {} }
   xpack_packetbeat_config_start_verify_import_dashboards:
     - { action: 'xpack_packetbeat_config',  parent: '', args: {} }
-    - { action: 'packetbeat_restart',  parent: 'packetbeat', args: {} }
+    - { action: 'packetbeat_startup',  parent: 'packetbeat', args: {} }
     - { action: 'packetbeat_is_running', parent: 'packetbeat', args: {} }
     - { action: 'packetbeat_import_dashboards', parent: 'packetbeat', args: {} }
   xpack_packetbeat_rmconfig_start_verify:
     - { action: 'xpack_packetbeat_config_remove', parent: '', args: {} }
-    - { action: 'packetbeat_restart',  parent: 'packetbeat', args: {} }
+    - { action: 'packetbeat_startup',  parent: 'packetbeat', args: {} }
     - { action: 'packetbeat_is_running', parent: 'packetbeat', args: {} }
 
 # Task files for group use, keep in sync with tasks/main.yml except for parent tasks

--- a/ansible/templates/logstash-conf.j2
+++ b/ansible/templates/logstash-conf.j2
@@ -4,7 +4,10 @@
 
 input {
   file {
-    path => "/var/log/syslog"
+    path => [
+				"/var/log/syslog",
+				"/var/log/messages"
+			]
     start_position => "beginning"
   }
 }

--- a/vm/vagrant/Vagrantfile
+++ b/vm/vagrant/Vagrantfile
@@ -27,11 +27,21 @@ $script = <<-SCRIPT
 
   # update vm map count
   sysctl -w vm.max_map_count=262144
+  
+  # CentOS specific changes. pipes are added to allow skipping on other OS
+  
+  # install lsof for Kibana_is_running.yml
+  yum -i install lsof || true
+  # enable outside access to the VM
+  iptables -F
+  # allow logstash.tar.gz to read this file
+  chmod 777 /var/log/messages || true
 SCRIPT
 
 # Default variables
 
 # Vagrant Info
+#VAGRANT_DEFAULT_BOX = "elastic/centos-7-x86_64"
 VAGRANT_DEFAULT_BOX = "elastic/ubuntu-16.04-x86_64"
 VAGRANT_DEFAULT_MEM = "4096"
 VAGRANT_DEFAULT_CPU = "2"


### PR DESCRIPTION
Adding the folllowing changes for making the tests work on CentOS. Current changes are only tested for .tar packages, I assume there will be more for the .rpm packages in the following days.

1. Changing from  ['ansible_eth0']['ipv4'] to ['ansible_default_ipv4'] . On CentOS 7, there is no ansible_eth0, so the other variable works on both Ubuntu and CentOS. 

2. Adding changes in the provisioning script: install lsof, iptables flush, and chmod on /var/log/messages

3. Add another log file in Logstash.conf for CentOS.

4. Changed "restart" to "startup" in the xpack playbooks as the products were not running and CentOS compains on kill commands that don't kill anything. Ubuntu doesn't complain. 