### PR TITLE
Monitoring parity: make room for other products

### DIFF
--- a/playbooks/monitoring/docs_parity.yml
+++ b/playbooks/monitoring/docs_parity.yml
@@ -1,0 +1,20 @@
+#----------------------------------------------------------------------------------------------------------------------
+# Playbook: Test for parity between metricbeat-indexes and internally-indexed Monitoring docs
+#
+# Author: shaunak@elastic.co
+#----------------------------------------------------------------------------------------------------------------------
+
+- hosts: "{{ uut | default(lookup('env','AIT_UUT')) }}"
+  roles:
+    - role: elasticsearch
+    - role: kibana
+    - role: metricbeat
+
+  vars:
+    monitoring_docs_dir: "{{ lookup('env', 'WORKSPACE') }}/monitoring/"
+
+  vars_files:
+    - "{{ es_var_file | default(lookup('env','ANSIBLE_GROUP_VARS')) }}"
+
+  tasks:
+  - include: kibana/docs_parity.yml

--- a/playbooks/monitoring/kibana/docs_compare.py
+++ b/playbooks/monitoring/kibana/docs_compare.py
@@ -1,6 +1,6 @@
 '''
 Usage:
-  python kibana_compare.py /path/to/internal/docs /path/to/metricbeat/docs
+  python docs_compare.py /path/to/internal/docs /path/to/metricbeat/docs
 '''
 
 import os

--- a/playbooks/monitoring/kibana/docs_parity.yml
+++ b/playbooks/monitoring/kibana/docs_parity.yml
@@ -173,6 +173,6 @@
         ait_action: elasticsearch_shutdown 
 
     - name: Compare internally-indexed and metricbeat-indexed documents for parity
-      shell: 'python ./scripts/python/kibana_compare.py {{ monitoring_docs_dir }}/kibana/internal {{ monitoring_docs_dir }}/kibana/metricbeat'
+      shell: 'python ./docs_compare.py {{ monitoring_docs_dir }}/kibana/internal {{ monitoring_docs_dir }}/kibana/metricbeat'
       delegate_to: localhost
   

--- a/playbooks/monitoring/kibana/docs_parity.yml
+++ b/playbooks/monitoring/kibana/docs_parity.yml
@@ -4,175 +4,161 @@
 # Author: shaunak@elastic.co
 #----------------------------------------------------------------------------------------------------------------------
 
-- hosts: "{{ uut | default(lookup('env','AIT_UUT')) }}"
-  roles:
-    - role: elasticsearch
-    - role: kibana
-    - role: metricbeat
+- name: Clean out old directories to hold monitoring sample docs files
+  file:
+    state: absent
+    path: "{{ monitoring_docs_dir }}/kibana"
+  delegate_to: localhost
 
+- name: Make directories to hold monitoring sample docs files
+  file:
+    state: directory
+    path: "{{ monitoring_docs_dir }}/kibana/{{ item }}/"
+  with_items:
+    - internal
+    - metricbeat
+  delegate_to: localhost
+
+- name: Start elasticsearch with monitoring collection enabled
+  include_role:
+    name: xpack_elasticsearch
   vars:
-    monitoring_docs_dir: "{{ lookup('env', 'WORKSPACE') }}/monitoring/"
+    elasticsearch_config_params: {"xpack.monitoring.collection.enabled: true"}
+    ait_role: xpack_elasticsearch_install_gencert_config_start_verify
 
-  vars_files:
-    - "{{ es_var_file | default(lookup('env','ANSIBLE_GROUP_VARS')) }}"
+- name: Start kibana
+  include_role:
+    name: xpack_kibana
+  vars:
+    ait_role: xpack_kibana_install_config_start_verify
 
-  tasks:
-    - name: Clean out old directories to hold monitoring sample docs files
-      file:
-        state: absent
-        path: "{{ monitoring_docs_dir }}/kibana"
-      delegate_to: localhost
+- name: Wait for kibana to index a few monitoring documents
+  wait_for:
+    timeout: 15
 
-    - name: Make directories to hold monitoring sample docs files
-      file:
-        state: directory
-        path: "{{ monitoring_docs_dir }}/kibana/{{ item }}/"
-      with_items:
-        - internal
-        - metricbeat
-      delegate_to: localhost
+- name: Stop kibana
+  include_role:
+    name: kibana
+  vars:
+    ait_role: kibana_shutdown_verify
 
-    - name: Start elasticsearch with monitoring collection enabled 
-      include_role: 
-        name: xpack_elasticsearch
-      vars:
-        elasticsearch_config_params: {"xpack.monitoring.collection.enabled: true"}
-        ait_role: xpack_elasticsearch_install_gencert_config_start_verify 
+- name: Get sample kibana-indexed docs from monitoring index
+  uri:
+    method: POST
+    url: "https://{{ current_host_ip }}:{{ elasticsearch_port }}/.monitoring-kibana-*/_search"
+    validate_certs: no
+    return_content: yes
+    user: "{{ elasticsearch_username }}"
+    password: "{{ elasticsearch_password }}"
+    body: '{ "collapse": { "field": "type" }, "sort": { "timestamp": "desc" } }'
+    body_format: json
+    status_code: 200
+  register: xpack_elasticsearch_monitoring_sample_docs
 
-    - name: Start kibana 
-      include_role: 
-        name: xpack_kibana
-      vars:
-        ait_role: xpack_kibana_install_config_start_verify 
+- name: Write sample docs to temp files
+  copy:
+    content: "{{ item._source }}"
+    dest: "{{ monitoring_docs_dir }}/kibana/internal/{{ item._source.type }}.json"
+  with_items: "{{ xpack_elasticsearch_monitoring_sample_docs.json.hits.hits }}"
+  delegate_to: localhost
 
-    - name: Wait for kibana to index a few monitoring documents
-      wait_for:
-        timeout: 15
+- name: Stop kibana internal monitoring
+  include_role:
+    name: kibana
+  vars:
+    kibana_config_params: {"xpack.monitoring.kibana.collection.enabled: false"}
+    ait_action: kibana_config
 
-    - name: Stop kibana 
-      include_role: 
-        name: kibana
-      vars: 
-        ait_role: kibana_shutdown_verify
+- name: Clean out kibana monitoring index
+  uri:
+    method: DELETE
+    url: "https://{{ current_host_ip }}:{{ elasticsearch_port }}/.monitoring-kibana-*"
+    validate_certs: no
+    user: "{{ elasticsearch_username }}"
+    password: "{{ elasticsearch_password }}"
+    status_code: 200
 
-    - name: Get sample kibana-indexed docs from monitoring index
-      uri:
-        method: POST
-        url: "https://{{ current_host_ip }}:{{ elasticsearch_port }}/.monitoring-kibana-*/_search"
-        validate_certs: no
-        return_content: yes
-        user: "{{ elasticsearch_username }}"
+- name: Start kibana
+  include_role:
+    name: kibana
+  vars:
+    ait_role: kibana_startup_verify
+
+- name: Install metricbeat
+  include_role:
+    name: metricbeat
+  vars:
+    ait_action: metricbeat_install
+
+- name: Enable metricbeat's kibana module
+  file:
+    path: '{{ metricbeat_rootdir }}/modules.d/kibana.yml.disabled'
+    state: absent
+  become: true
+
+- name: Configure metricbeat's kibana module to collect monitoring documents
+  copy:
+    dest: '{{ metricbeat_rootdir }}/modules.d/kibana.yml'
+    content: |
+      - module: kibana
+        metricsets:
+        - stats
+        period: 10s
+        hosts: ["https://{{ current_host_ip }}:{{ kibana_port }}"]
+        ssl.verification_mode: none
+        username: "{{ elasticsearch_username }}"
         password: "{{ elasticsearch_password }}"
-        body: '{ "collapse": { "field": "type" }, "sort": { "timestamp": "desc" } }'
-        body_format: json
-        status_code: 200
-      register: xpack_elasticsearch_monitoring_sample_docs
+        xpack.enabled: true
+  become: true
 
-    - name: Write sample docs to temp files
-      copy:
-        content: "{{ item._source }}"
-        dest: "{{ monitoring_docs_dir }}/kibana/internal/{{ item._source.type }}.json"
-      with_items: "{{ xpack_elasticsearch_monitoring_sample_docs.json.hits.hits }}"
-      delegate_to: localhost
-      
-    - name: Stop kibana internal monitoring 
-      include_role: 
-        name: kibana
-      vars:
-        kibana_config_params: {"xpack.monitoring.kibana.collection.enabled: false"}
-        ait_action: kibana_config
+- name: Start metricbeat
+  include_role:
+    name: xpack_metricbeat
+  vars:
+    ait_role: xpack_metricbeat_config_start_verify
 
-    - name: Clean out kibana monitoring index
-      uri:
-        method: DELETE
-        url: "https://{{ current_host_ip }}:{{ elasticsearch_port }}/.monitoring-kibana-*"
-        validate_certs: no
-        user: "{{ elasticsearch_username }}"
-        password: "{{ elasticsearch_password }}"
-        status_code: 200
+- name: Wait for metricbeat to index a few monitoring documents
+  wait_for:
+    timeout: 15
 
-    - name: Start kibana 
-      include_role: 
-        name: kibana
-      vars: 
-        ait_role: kibana_startup_verify
+- name: Stop metricbeat
+  include_role:
+    name: metricbeat
+  vars:
+    ait_action: metricbeat_shutdown
 
-    - name: Install metricbeat
-      include_role:
-        name: metricbeat
-      vars:
-        ait_action: metricbeat_install
+- name: Stop kibana
+  include_role:
+    name: kibana
+  vars:
+    ait_role: kibana_shutdown_verify
 
-    - name: Enable metricbeat's kibana module
-      file:
-        path: '{{ metricbeat_rootdir }}/modules.d/kibana.yml.disabled'
-        state: absent
-      become: true
+- name: Get sample metricbeat-indexed docs from monitoring index
+  uri:
+    url: "https://{{ current_host_ip }}:{{ elasticsearch_port }}/.monitoring-kibana-*/_search"
+    validate_certs: no
+    return_content: yes
+    user: "{{ elasticsearch_username }}"
+    password: "{{ elasticsearch_password }}"
+    method: POST
+    body: '{ "collapse": { "field": "type" }, "sort": { "timestamp": "desc" } }'
+    body_format: json
+    status_code: 200
+  register: xpack_elasticsearch_monitoring_sample_docs
 
-    - name: Configure metricbeat's kibana module to collect monitoring documents
-      copy:
-        dest: '{{ metricbeat_rootdir }}/modules.d/kibana.yml'
-        content: |
-          - module: kibana
-            metricsets:
-            - stats
-            period: 10s
-            hosts: ["https://{{ current_host_ip }}:{{ kibana_port }}"]
-            ssl.verification_mode: none
-            username: "{{ elasticsearch_username }}"
-            password: "{{ elasticsearch_password }}"
-            xpack.enabled: true
-      become: true
+- name: Write sample docs to temp files
+  copy:
+    content: "{{ item._source }}"
+    dest: "{{ monitoring_docs_dir }}/kibana/metricbeat/{{ item._source.type }}.json"
+  with_items: "{{ xpack_elasticsearch_monitoring_sample_docs.json.hits.hits }}"
+  delegate_to: localhost
 
-    - name: Start metricbeat
-      include_role:
-        name: xpack_metricbeat
-      vars:
-        ait_role: xpack_metricbeat_config_start_verify
+- name: Stop elasticsearch
+  include_role:
+    name: elasticsearch
+  vars:
+    ait_action: elasticsearch_shutdown
 
-    - name: Wait for metricbeat to index a few monitoring documents
-      wait_for:
-        timeout: 15
-
-    - name: Stop metricbeat 
-      include_role: 
-        name: metricbeat
-      vars: 
-        ait_action: metricbeat_shutdown 
-
-    - name: Stop kibana 
-      include_role: 
-        name: kibana
-      vars: 
-        ait_role: kibana_shutdown_verify
-
-    - name: Get sample metricbeat-indexed docs from monitoring index
-      uri:
-        url: "https://{{ current_host_ip }}:{{ elasticsearch_port }}/.monitoring-kibana-*/_search"
-        validate_certs: no
-        return_content: yes
-        user: "{{ elasticsearch_username }}"
-        password: "{{ elasticsearch_password }}"
-        method: POST
-        body: '{ "collapse": { "field": "type" }, "sort": { "timestamp": "desc" } }'
-        body_format: json
-        status_code: 200
-      register: xpack_elasticsearch_monitoring_sample_docs
-
-    - name: Write sample docs to temp files
-      copy:
-        content: "{{ item._source }}"
-        dest: "{{ monitoring_docs_dir }}/kibana/metricbeat/{{ item._source.type }}.json"
-      with_items: "{{ xpack_elasticsearch_monitoring_sample_docs.json.hits.hits }}"
-      delegate_to: localhost
-
-    - name: Stop elasticsearch
-      include_role: 
-        name: elasticsearch
-      vars: 
-        ait_action: elasticsearch_shutdown 
-
-    - name: Compare internally-indexed and metricbeat-indexed documents for parity
-      shell: 'python ./docs_compare.py {{ monitoring_docs_dir }}/kibana/internal {{ monitoring_docs_dir }}/kibana/metricbeat'
-      delegate_to: localhost
-  
+- name: Compare internally-indexed and metricbeat-indexed documents for parity
+  shell: 'python {{ playbook_dir }}/kibana/docs_compare.py {{ monitoring_docs_dir }}/kibana/internal {{ monitoring_docs_dir }}/kibana/metricbeat'
+  delegate_to: localhost


### PR DESCRIPTION
Currently the monitoring parity tests are focussed on Kibana. That is, they are focussed on comparing kibana-indexed monitoring documents with metricbeat-indexed monitoring documents to ensure that there is parity between them.

Going forward we will be requiring similar tests for other products, likely starting with Elasticsearch next.

This PR simply refactors the current setup under `playbooks/monitoring` to make room for kibana and other products in the future.