### PR TITLE
Fix CI failures for 7.0.0/master build jobs

### DIFF
--- a/ansible/roles/xpack_elasticsearch/tasks/linux/xpack_elasticsearch_config.yml
+++ b/ansible/roles/xpack_elasticsearch/tasks/linux/xpack_elasticsearch_config.yml
@@ -39,6 +39,7 @@
     insertafter: EOF
     content: |
       network.host: {{ current_host_ip }}
+      discovery.zen.ping.unicast.hosts: {{ current_host_ip }}
       xpack.security.enabled: true
       xpack.license.self_generated.type: trial
       xpack.security.http.ssl.enabled: true


### PR DESCRIPTION
ESTF CI jobs for master/7.0.0 are failing like so:

> 09:09:32 TASK [elasticsearch : Wait for elasticsearch log string] ***********************
09:10:33 fatal: [aithost]: FAILED! => {"changed": true, "cmd": "timeout \"60\" sed -r '/Node.*started/q' <(tail -n 0 -f \"/tmp/elasticsearch-7.0.0-SNAPSHOT/logs/elasticsearch.log\")", "delta": "0:01:01.041113", "end": "2018-12-17 17:10:31.962176", "failed": true, "rc": 124, "start": "2018-12-17 17:09:30.921063", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

I reproduced this locally and checked the ES log in the Vagrant VM. Long story short, we need to set `discovery.zen.ping.unicast.hosts: {{ current_host_ip }}` if also setting `network.host: {{ current_host_ip }}` starting with ES 7.0.0. This PR makes this change.