### PR TITLE
Updating Kibana compare script

### DIFF
--- a/playbooks/monitoring/kibana/docs_compare.py
+++ b/playbooks/monitoring/kibana/docs_compare.py
@@ -117,19 +117,14 @@ for doc_type in internal_doc_types:
 
     difference = diff(internal_doc, metricbeat_doc, syntax='explicit', marshal=True)
 
-    # Expect there to be exactly four top-level insertions to the metricbeat-indexed doc: beat, @timestamp, host, and metricset
-    expected_insertions = [ "beat", "@timestamp", "host", "metricset" ]
+    # Expect there to be exactly seven top-level insertions to the metricbeat-indexed doc: service, beat, agent, @timestamp, host, event, and metricset
+    allowed_insertions = [ "service", "beat", "agent", "@timestamp", "host", "event", "metricset" ]
     insertions = difference.get('$insert')
     if insertions == None or len(insertions) < 1:
-        log_parity_error("Metricbeat-indexed doc for type='" + doc_type + "' has no insertions. Expected 'beat', '@timestamp', 'host', and 'metricset' to be inserted.")
+        log_parity_error("Metricbeat-indexed doc for type='" + doc_type + "' has no insertions. Expected up to " + len(allowed_insertions) + " to be inserted.")
 
-    if len(insertions) > 4:
-        log_parity_error("Metricbeat-indexed doc for type='" + doc_type + "' has too many insertions: " + json.dumps(deletions))
-
-    insertion_keys = insertions.keys()
-    for expected_insertion in expected_insertions:
-        if expected_insertion not in insertion_keys:
-            log_parity_error("Metricbeat-indexed doc for type='" + doc_type + "' does not have '" + expected_insertion + "' inserted.")
+    if len(insertions) > len(allowed_insertions):
+        log_parity_error("Metricbeat-indexed doc for type='" + doc_type + "' has too many insertions: " + json.dumps(insertions))
 
     difference.pop('$insert') 
 


### PR DESCRIPTION
Due to recent changes in Metricbeat-indexed documents because of the introduction of ECS, the compare script needed to be updated.