### PR TITLE
[7.x] Monitoring parity tests: Add playbook and script for Elasticsearch (#29)

### DIFF
--- a/playbooks/monitoring/docs_parity.yml
+++ b/playbooks/monitoring/docs_parity.yml
@@ -18,3 +18,5 @@
 
   tasks:
   - include: kibana/docs_parity.yml
+  - include: elasticsearch/docs_parity.yml
+  

--- a/playbooks/monitoring/elasticsearch/docs_parity.yml
+++ b/playbooks/monitoring/elasticsearch/docs_parity.yml
@@ -1,0 +1,162 @@
+#----------------------------------------------------------------------------------------------------------------------
+# Playbook: Test for parity between metricbeat-indexes and internally-indexed Monitoring docs
+#
+# Author: shaunak@elastic.co
+#----------------------------------------------------------------------------------------------------------------------
+
+- name: Clean out old directories to hold monitoring sample docs files
+  file:
+    state: absent
+    path: "{{ monitoring_docs_dir }}/elasticsearch"
+  delegate_to: localhost
+
+- name: Make directories to hold monitoring sample docs files
+  file:
+    state: directory
+    path: "{{ monitoring_docs_dir }}/elasticsearch/{{ item }}/"
+  with_items:
+    - internal
+    - metricbeat
+  delegate_to: localhost
+
+- name: Start elasticsearch
+  include_role:
+    name: xpack_elasticsearch
+  vars:
+    ait_role: xpack_elasticsearch_install_gencert_config_start_verify
+
+- name: Enable internal monitoring collection
+  uri:
+    method: PUT
+    url: "https://{{ current_host_ip }}:{{ elasticsearch_port }}/_cluster/settings"
+    body: '{ "transient": { "xpack.monitoring.collection.enabled": true } }'
+    body_format: json
+    validate_certs: no
+    user: "{{ elasticsearch_username }}"
+    password: "{{ elasticsearch_password }}"
+    status_code: 200
+
+- name: Wait for elasticsearch to index a few monitoring documents
+  wait_for:
+    timeout: 15
+
+- name: Get sample elasticsearch-indexed docs from monitoring index
+  uri:
+    method: POST
+    url: "https://{{ current_host_ip }}:{{ elasticsearch_port }}/.monitoring-es-*/_search"
+    validate_certs: no
+    return_content: yes
+    user: "{{ elasticsearch_username }}"
+    password: "{{ elasticsearch_password }}"
+    body: '{ "collapse": { "field": "type" }, "sort": { "timestamp": "desc" } }'
+    body_format: json
+    status_code: 200
+  register: xpack_elasticsearch_monitoring_sample_docs
+
+- name: Write sample docs to temp files
+  copy:
+    content: "{{ item._source }}"
+    dest: "{{ monitoring_docs_dir }}/elasticsearch/internal/{{ item._source.type }}.json"
+  with_items: "{{ xpack_elasticsearch_monitoring_sample_docs.json.hits.hits }}"
+  delegate_to: localhost
+
+- name: Disable internal monitoring collection
+  uri:
+    method: PUT
+    url: "https://{{ current_host_ip }}:{{ elasticsearch_port }}/_cluster/settings"
+    body: '{ "transient": { "xpack.monitoring.collection.enabled": false } }'
+    body_format: json
+    validate_certs: no
+    user: "{{ elasticsearch_username }}"
+    password: "{{ elasticsearch_password }}"
+    status_code: 200
+
+
+- name: Clean out elasticsearch monitoring index
+  uri:
+    method: DELETE
+    url: "https://{{ current_host_ip }}:{{ elasticsearch_port }}/.monitoring-es-*"
+    validate_certs: no
+    user: "{{ elasticsearch_username }}"
+    password: "{{ elasticsearch_password }}"
+    status_code: 200
+
+- name: Install metricbeat
+  include_role:
+    name: metricbeat
+  vars:
+    ait_action: metricbeat_install
+
+- name: Enable metricbeat's elasticsearch module
+  file:
+    path: '{{ metricbeat_rootdir }}/modules.d/elasticsearch.yml.disabled'
+    state: absent
+  become: true
+
+- name: Configure metricbeat's elasticsearch module to collect monitoring documents
+  copy:
+    dest: '{{ metricbeat_rootdir }}/modules.d/kibana.yml'
+    content: |
+      - module: elasticsearch
+        metricsets:
+        - ccr
+        - cluster_stats
+        - index
+        - index_recovery
+        - index_summary
+        - ml_job
+        - node_stats
+        - shard
+        period: 10s
+        hosts: ["https://{{ current_host_ip }}:{{ elasticsearch_port }}"]
+        ssl.verification_mode: none
+        username: "{{ elasticsearch_username }}"
+        password: "{{ elasticsearch_password }}"
+        xpack.enabled: true
+  become: true
+
+- name: Start metricbeat
+  include_role:
+    name: xpack_metricbeat
+  vars:
+    ait_role: xpack_metricbeat_config_start_verify
+
+- name: Wait for metricbeat to index a few monitoring documents
+  wait_for:
+    timeout: 15
+
+- name: Stop metricbeat
+  include_role:
+    name: metricbeat
+  vars:
+    ait_action: metricbeat_shutdown
+
+- name: Get sample metricbeat-indexed docs from monitoring index
+  uri:
+    url: "https://{{ current_host_ip }}:{{ elasticsearch_port }}/.monitoring-es-*/_search"
+    validate_certs: no
+    return_content: yes
+    user: "{{ elasticsearch_username }}"
+    password: "{{ elasticsearch_password }}"
+    method: POST
+    body: '{ "collapse": { "field": "type" }, "sort": { "timestamp": "desc" } }'
+    body_format: json
+    status_code: 200
+  register: xpack_elasticsearch_monitoring_sample_docs
+
+- name: Write sample docs to temp files
+  copy:
+    content: "{{ item._source }}"
+    dest: "{{ monitoring_docs_dir }}/elasticsearch/metricbeat/{{ item._source.type }}.json"
+  with_items: "{{ xpack_elasticsearch_monitoring_sample_docs.json.hits.hits }}"
+  delegate_to: localhost
+
+- name: Stop elasticsearch
+  include_role:
+    name: elasticsearch
+  vars:
+    ait_action: elasticsearch_shutdown
+
+- name: Compare internally-indexed and metricbeat-indexed documents for parity
+  shell: 'python {{ playbook_dir }}/elasticsearch/docs_compare.py {{ monitoring_docs_dir }}/elasticsearch/internal {{ monitoring_docs_dir }}/elasticsearch/metricbeat'
+  delegate_to: localhost


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Monitoring parity tests: Add playbook and script for Elasticsearch  (#29)