### PR TITLE
[7.x] Fix typo in variable name (#160)

### DIFF
--- a/playbooks/monitoring/elasticsearch/docs_compare.py
+++ b/playbooks/monitoring/elasticsearch/docs_compare.py
@@ -117,7 +117,7 @@ for doc_type in internal_doc_types:
         log_parity_error("Metricbeat-indexed doc for type='" + doc_type + "' has no insertions. Expected 'beat', '@timestamp', 'host', and 'metricset' to be inserted.")
 
     if len(insertions) > 4:
-        log_parity_error("Metricbeat-indexed doc for type='" + doc_type + "' has too many insertions: " + json.dumps(deletions))
+        log_parity_error("Metricbeat-indexed doc for type='" + doc_type + "' has too many insertions: " + json.dumps(insertions))
 
     insertion_keys = insertions.keys()
     for expected_insertion in expected_insertions:


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Fix typo in variable name  (#160)