### PR TITLE
[6.7] Fetch *first* docs (instead of latest) from .monitoring-kibana-* (#207)

### DIFF
--- a/playbooks/monitoring/docs_parity.yml
+++ b/playbooks/monitoring/docs_parity.yml
@@ -63,7 +63,7 @@
         return_content: yes
         user: "{{ elasticsearch_username }}"
         password: "{{ elasticsearch_password }}"
-        body: '{ "collapse": { "field": "type" } }'
+        body: '{ "collapse": { "field": "type" }, "sort": { "timestamp": "asc" } }'
         body_format: json
         status_code: 200
       register: xpack_elasticsearch_monitoring_sample_docs
@@ -154,7 +154,7 @@
         user: "{{ elasticsearch_username }}"
         password: "{{ elasticsearch_password }}"
         method: POST
-        body: '{ "collapse": { "field": "type" } }'
+        body: '{ "collapse": { "field": "type" }, "sort": { "timestamp": "asc" } }'
         body_format: json
         status_code: 200
       register: xpack_elasticsearch_monitoring_sample_docs


### PR DESCRIPTION
Backports the following commits to 6.7:
 - Fetch *first* docs (instead of latest) from .monitoring-kibana-*  (#207)