### PR TITLE
[7.2] Fixing typo in file name (#233)

### DIFF
--- a/playbooks/monitoring/elasticsearch/docs_parity.yml
+++ b/playbooks/monitoring/elasticsearch/docs_parity.yml
@@ -107,7 +107,7 @@
 
     - name: Configure metricbeat's elasticsearch module to collect monitoring documents
       copy:
-        dest: '{{ metricbeat_rootdir }}/modules.d/kibana.yml'
+        dest: '{{ metricbeat_rootdir }}/modules.d/elasticsearch.yml'
         content: |
           - module: elasticsearch
             metricsets:


### PR DESCRIPTION
Backports the following commits to 7.2:
 - Fixing typo in file name  (#233)