### PR TITLE
Add exceptions for source_node field

### DIFF
--- a/playbooks/monitoring/elasticsearch/docs_compare.py
+++ b/playbooks/monitoring/elasticsearch/docs_compare.py
@@ -147,6 +147,11 @@ for doc_type in internal_doc_types:
 
     difference.pop('$delete') 
 
+    if doc_type == 'node_stats' or doc_type == 'shards':
+      if deletions[0] == 'source_node':
+        # type:node_stats and type:shards docs still need the source_node field since the UI depends on it
+        log_parity_error("Metricbeat-index doc for type='" + doc_type +"' must contain source_node field.")
+
     # Updates are okay in metricbeat-indexed docs, but insertions and deletions are not
     if has_insertions_recursive(difference):
         log_parity_error("Metricbeat-indexed doc for type='" + doc_type + "' has unexpected insertions. Difference: " + json.dumps(difference, indent=2))

--- a/playbooks/monitoring/elasticsearch/docs_compare.py
+++ b/playbooks/monitoring/elasticsearch/docs_compare.py
@@ -141,7 +141,8 @@ for doc_type in internal_doc_types:
     if len(deletions) > 1:
         log_parity_error("Metricbeat-indexed doc for type='" + doc_type + "' has too many deletions: " + json.dumps(deletions))
 
-    if deletions[0] != 'source_node':
+    if deletions[0] != 'source_node' and doc_type != 'node_stats' and doc_type != 'shards':
+        # type:node_stats and type:shards docs still need the source_node field since the UI depends on it
         log_parity_error("Metricbeat-indexed doc for type='" + doc_type + "' does not have 'source_node' deleted.")
 
     difference.pop('$delete') 


### PR DESCRIPTION
When the internal/native monitoring method is used, the Elasticsearch production cluster adds a `source_node` field to monitoring documents. Originally the intent of this field was for debugging purposes to know which production cluster node exported the monitoring data to the monitoring cluster.

Unfortunately over time, however, the Monitoring UI came to rely on this field in the case of Elasticsearch monitoring data, specifically for documents with `type:node_stats` or `type:shards`. That's because in such documents, the `source_node` field is _also_ indicative of the Elasticsearch node that the node stats are actually about (for `type:node_stats` documents) or of the Elasticearch node on which the shard lives (for `type:shards` documents).

To account for this misuse, Metricbeat `elasticsearch/node_stats` and `elasticsearch/shards` also started injecting a `source_node` field for these two types of docs. This way, the `.monitoring-es*` docs for `type:node_stats` and `type:shards` produced by external collection also contain the `source_node` field, akin to their internally-collected counterparts.

Given all this, the parity tests must make an exception for `type:node_stats` and `type:shards` documents indexed via external collection. They must allow such documents to contain a `source_node` field. In fact, they must _require_ that such documents contain a `source_node` field. This PR makes the necessary exception and additional assertion.