### PR TITLE
[7.x] Configure Filebeat to send monitoring data via production cluster (#255)

### DIFF
--- a/playbooks/monitoring/beat/docs_compare.py
+++ b/playbooks/monitoring/beat/docs_compare.py
@@ -121,9 +121,18 @@ for doc_type in internal_doc_types:
 
     difference.pop('$insert') 
 
+    # Expect there to be exactly one top-level deletion from metricbeat-indexed doc: source_node
     deletions = difference.get('$delete')
-    if deletions and len(deletions) > 0:
+    if deletions == None or len(deletions) < 1:
+        log_parity_error("Metricbeat-indexed doc for type='" + doc_type + "' has no deletions. Expected 'source_node' to be deleted.")
+
+    if len(deletions) > 1:
         log_parity_error("Metricbeat-indexed doc for type='" + doc_type + "' has too many deletions: " + json.dumps(deletions))
+
+    if deletions[0] != 'source_node':
+        log_parity_error("Metricbeat-indexed doc for type='" + doc_type + "' does not have 'source_node' deleted.")
+
+    difference.pop('$delete') 
 
     # Updates are okay in metricbeat-indexed docs, but insertions and deletions are not
     if has_insertions_recursive(difference):

--- a/playbooks/monitoring/beat/docs_parity.yml
+++ b/playbooks/monitoring/beat/docs_parity.yml
@@ -46,7 +46,7 @@
       vars:
         ait_role: xpack_filebeat_install_config_start_verify
         filebeat_config_params: |
-          monitoring.enabled: true
+          xpack.monitoring.enabled: true
 
     - name: Wait for filebeat to index a few monitoring documents
       wait_for:


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Configure Filebeat to send monitoring data via production cluster  (#255)