### PR TITLE
Print the diff when list lengths differ

### DIFF
--- a/playbooks/monitoring/beat/docs_compare.py
+++ b/playbooks/monitoring/beat/docs_compare.py
@@ -105,7 +105,7 @@ metricbeat_doc_types = get_doc_types(metricbeat_docs_path)
 if len(internal_doc_types) > len(metricbeat_doc_types):
     diff_elements = set(internal_doc_types) - set(metricbeat_doc_types)
     log_parity_error("Found more internally-indexed document types than metricbeat-indexed document types.\n \
-            Elements which appear in the internal collector but not in Metricbeat:{}\n".format(pprint.pformat(diff_elements)))
+            Document types indexed by internal collection but not by Metricbeat collection: {}".format(pprint.pformat(diff_elements)))
 for doc_type in internal_doc_types:
     internal_doc = get_doc(internal_docs_path, doc_type)
     metricbeat_doc = get_doc(metricbeat_docs_path, doc_type)

--- a/playbooks/monitoring/beat/docs_compare.py
+++ b/playbooks/monitoring/beat/docs_compare.py
@@ -105,7 +105,7 @@ metricbeat_doc_types = get_doc_types(metricbeat_docs_path)
 if len(internal_doc_types) > len(metricbeat_doc_types):
     diff_elements = set(internal_doc_types) - set(metricbeat_doc_types)
     log_parity_error("Found more internally-indexed document types than metricbeat-indexed document types.\n \
-            Elements which appear in the internal collector but not in Metricbeat:\n".format(pprint.pformat(diff_elements)))
+            Elements which appear in the internal collector but not in Metricbeat:{}\n".format(pprint.pformat(diff_elements)))
 for doc_type in internal_doc_types:
     internal_doc = get_doc(internal_docs_path, doc_type)
     metricbeat_doc = get_doc(metricbeat_docs_path, doc_type)

--- a/playbooks/monitoring/beat/docs_compare.py
+++ b/playbooks/monitoring/beat/docs_compare.py
@@ -7,6 +7,7 @@ import os
 import sys
 from jsondiff import diff
 import json
+import pprint
 
 def get_doc_types(docs_path):
     files = os.listdir(docs_path)
@@ -102,8 +103,9 @@ internal_doc_types = get_doc_types(internal_docs_path)
 metricbeat_doc_types = get_doc_types(metricbeat_docs_path)
 
 if len(internal_doc_types) > len(metricbeat_doc_types):
-    log_parity_error("Found more internally-indexed document types than metricbeat-indexed document types")
-
+    diff_elements = set(internal_doc_types) - set(metricbeat_doc_types)
+    log_parity_error("Found more internally-indexed document types than metricbeat-indexed document types.\n \
+            Elements which appear in the internal collector but not in Metricbeat:\n".format(pprint.pformat(diff_elements)))
 for doc_type in internal_doc_types:
     internal_doc = get_doc(internal_docs_path, doc_type)
     metricbeat_doc = get_doc(metricbeat_docs_path, doc_type)

--- a/playbooks/monitoring/elasticsearch/docs_compare.py
+++ b/playbooks/monitoring/elasticsearch/docs_compare.py
@@ -115,7 +115,7 @@ metricbeat_doc_types = get_doc_types(metricbeat_docs_path)
 if len(internal_doc_types) > len(metricbeat_doc_types):
     diff_elements = set(internal_doc_types) - set(metricbeat_doc_types)
     log_parity_error("Found more internally-indexed document types than metricbeat-indexed document types.\n \
-            Elements which appear in the internal collector but not in Metricbeat:{}\n".format(pprint.pformat(diff_elements)))
+            Document types indexed by internal collection but not by Metricbeat collection: {}\n".format(pprint.pformat(diff_elements)))
 
 for doc_type in internal_doc_types:
     internal_doc = get_doc(internal_docs_path, doc_type)

--- a/playbooks/monitoring/elasticsearch/docs_compare.py
+++ b/playbooks/monitoring/elasticsearch/docs_compare.py
@@ -115,7 +115,7 @@ metricbeat_doc_types = get_doc_types(metricbeat_docs_path)
 if len(internal_doc_types) > len(metricbeat_doc_types):
     diff_elements = set(internal_doc_types) - set(metricbeat_doc_types)
     log_parity_error("Found more internally-indexed document types than metricbeat-indexed document types.\n \
-            Elements which appear in the internal collector but not in Metricbeat:\n".format(pprint.pformat(diff_elements)))
+            Elements which appear in the internal collector but not in Metricbeat:{}\n".format(pprint.pformat(diff_elements)))
 
 for doc_type in internal_doc_types:
     internal_doc = get_doc(internal_docs_path, doc_type)

--- a/playbooks/monitoring/elasticsearch/docs_compare.py
+++ b/playbooks/monitoring/elasticsearch/docs_compare.py
@@ -7,6 +7,7 @@ import os
 import sys
 from jsondiff import diff
 import json
+import pprint
 
 def get_doc_types(docs_path):
     files = os.listdir(docs_path)
@@ -112,7 +113,9 @@ internal_doc_types = get_doc_types(internal_docs_path)
 metricbeat_doc_types = get_doc_types(metricbeat_docs_path)
 
 if len(internal_doc_types) > len(metricbeat_doc_types):
-    log_parity_error("Found more internally-indexed document types than metricbeat-indexed document types")
+    diff_elements = set(internal_doc_types) - set(metricbeat_doc_types)
+    log_parity_error("Found more internally-indexed document types than metricbeat-indexed document types.\n \
+            Elements which appear in the internal collector but not in Metricbeat:\n".format(pprint.pformat(diff_elements)))
 
 for doc_type in internal_doc_types:
     internal_doc = get_doc(internal_docs_path, doc_type)

--- a/playbooks/monitoring/kibana/docs_compare.py
+++ b/playbooks/monitoring/kibana/docs_compare.py
@@ -105,7 +105,7 @@ metricbeat_doc_types = get_doc_types(metricbeat_docs_path)
 if len(internal_doc_types) > len(metricbeat_doc_types):
     diff_elements = set(internal_doc_types) - set(metricbeat_doc_types)
     log_parity_error("Found more internally-indexed document types than metricbeat-indexed document types.\n \
-            Elements which appear in the internal collector but not in Metricbeat:\n".format(pprint.pformat(diff_elements)))
+            Elements which appear in the internal collector but not in Metricbeat:{}\n".format(pprint.pformat(diff_elements)))
 
 for doc_type in internal_doc_types:
     internal_doc = get_doc(internal_docs_path, doc_type)

--- a/playbooks/monitoring/kibana/docs_compare.py
+++ b/playbooks/monitoring/kibana/docs_compare.py
@@ -105,7 +105,7 @@ metricbeat_doc_types = get_doc_types(metricbeat_docs_path)
 if len(internal_doc_types) > len(metricbeat_doc_types):
     diff_elements = set(internal_doc_types) - set(metricbeat_doc_types)
     log_parity_error("Found more internally-indexed document types than metricbeat-indexed document types.\n \
-            Elements which appear in the internal collector but not in Metricbeat:{}\n".format(pprint.pformat(diff_elements)))
+            Document types indexed by internal collection but not by Metricbeat collection: {}\n".format(pprint.pformat(diff_elements)))
 
 for doc_type in internal_doc_types:
     internal_doc = get_doc(internal_docs_path, doc_type)

--- a/playbooks/monitoring/kibana/docs_compare.py
+++ b/playbooks/monitoring/kibana/docs_compare.py
@@ -7,6 +7,7 @@ import os
 import sys
 from jsondiff import diff
 import json
+import pprint
 
 def get_doc_types(docs_path):
     files = os.listdir(docs_path)
@@ -102,7 +103,9 @@ internal_doc_types = get_doc_types(internal_docs_path)
 metricbeat_doc_types = get_doc_types(metricbeat_docs_path)
 
 if len(internal_doc_types) > len(metricbeat_doc_types):
-    log_parity_error("Found more internally-indexed document types than metricbeat-indexed document types")
+    diff_elements = set(internal_doc_types) - set(metricbeat_doc_types)
+    log_parity_error("Found more internally-indexed document types than metricbeat-indexed document types.\n \
+            Elements which appear in the internal collector but not in Metricbeat:\n".format(pprint.pformat(diff_elements)))
 
 for doc_type in internal_doc_types:
     internal_doc = get_doc(internal_docs_path, doc_type)


### PR DESCRIPTION
When the list lengths of types differ, print what is different to aid in debugging. 

Produces output like the following:

```
ERROR: Found more internally-indexed document types than metricbeat-indexed document types.
             Elements which appear in the internal collector but not in Metricbeat:{'kibana_stats', 'kibana_settings'}

```