### PR TITLE
Give Elasticsearch more time to shut down

### DIFF
--- a/ansible/roles/elasticsearch/tasks/linux/elasticsearch_is_not_running.yml
+++ b/ansible/roles/elasticsearch/tasks/linux/elasticsearch_is_not_running.yml
@@ -12,6 +12,9 @@
       args:
         executable: /bin/bash
       register: elasticsearch_process_id
+      retries: 5
+      delay: 3
+      until: elasticsearch_process_id.stdout == ""
     - name: Fail if elasticsearch process is running
       fail:
         msg: 'elasticsearch is running'


### PR DESCRIPTION
ESTF Elasticsearch Monitoring Parity Test build jobs are [failing](https://internal-ci.elastic.co/job/elastic+estf-monitoring-snapshots+master+multijob-elasticsearch/17/console) with the following error:

```
TASK [elasticsearch : Fail if elasticsearch process is running] ****************
14:55:21 fatal: [aithost]: FAILED! => {
14:55:21     "changed": false
14:55:21 }
14:55:21 
14:55:21 MSG:
14:55:21 
14:55:21 elasticsearch is running
```

I [re-ran](https://internal-ci.elastic.co/job/elastic+estf-monitoring-snapshots+master+multijob-elasticsearch/20/console) the same build job but it failed in the same way.

Next, I tried to reproduce this failure locally multiple times but wasn't able to. It always got past the failed task seen in the CI output. 

I can't see logs of what's happening in CI but my suspicion is that we might need to give Elasticsearch more time to shutdown in the CI environment.

This PR gives Elasticsearch 15 seconds more to shut down, by re-checking for it's PID every 3 seconds up to 5 times.