### PR TITLE
[6.8] Skip Logstash parity tests

### DIFF
--- a/playbooks/monitoring/logstash/docs_parity.yml
+++ b/playbooks/monitoring/logstash/docs_parity.yml
@@ -1,0 +1,12 @@
+#----------------------------------------------------------------------------------------------------------------------
+# Playbook: Test for parity between metricbeat-indexed and internally-indexed Monitoring docs
+#
+# Author: shaunak@elastic.co
+#----------------------------------------------------------------------------------------------------------------------
+
+- hosts: "{{ uut | default(lookup('env','AIT_UUT')) }}"
+
+  tasks:
+    - name: NOOP
+      debug:
+        msg: Nothing to do for logstash parity tests as the logstash Metricbeat module is only available starting 7.3.0


### PR DESCRIPTION
This PR skips the Logstash parity tests in the `6.8` branch because the `logstash` Metricbeat module isn't available until `7.3.0`.