### PR TITLE
[6.8] Give Logstash more time to shut down (#303)

### DIFF
--- a/ansible/roles/elasticsearch/tasks/linux/elasticsearch_is_not_running.yml
+++ b/ansible/roles/elasticsearch/tasks/linux/elasticsearch_is_not_running.yml
@@ -15,7 +15,3 @@
       retries: 5
       delay: 3
       until: elasticsearch_process_id.stdout == ""
-    - name: Fail if elasticsearch process is running
-      fail:
-        msg: 'elasticsearch is running'
-      when: elasticsearch_process_id.stdout != ""

--- a/ansible/roles/logstash/tasks/linux/logstash_is_not_running.yml
+++ b/ansible/roles/logstash/tasks/linux/logstash_is_not_running.yml
@@ -12,7 +12,6 @@
       args:
         executable: /bin/bash
       register: logstash_process_id
-    - name: Fail if logstash process is running
-      fail:
-        msg: 'logstash is running'
-      when: logstash_process_id.stdout != ""
+      retries: 5
+      delay: 3
+      until: logstash_process_id.stdout == ""


### PR DESCRIPTION
Backports the following commits to 6.8:
 - Give Logstash more time to shut down  (#303)