### PR TITLE
Prepare for upcoming deprecation of endpoint

### DIFF
--- a/ansible/roles/xpack_elasticsearch/tasks/linux/xpack_elasticsearch_create_users_roles.yml
+++ b/ansible/roles/xpack_elasticsearch/tasks/linux/xpack_elasticsearch_create_users_roles.yml
@@ -8,7 +8,7 @@
 
 - name: Add Users and Roles
   uri:
-    url: "https://{{ current_host_ip }}:{{ elasticsearch_port }}/_xpack/security/{{ role_user.path }}"
+    url: "https://{{ current_host_ip }}:{{ elasticsearch_port }}/_security/{{ role_user.path }}"
     method: POST
     user: "{{ elasticsearch_username }}"
     password: "{{ elasticsearch_password }}"

--- a/ansible/roles/xpack_elasticsearch/tasks/linux/xpack_elasticsearch_set_passwords.yml
+++ b/ansible/roles/xpack_elasticsearch/tasks/linux/xpack_elasticsearch_set_passwords.yml
@@ -59,7 +59,7 @@
 
 - name: Set elastic password
   uri:
-    url: "https://{{ current_host_ip }}:{{ elasticsearch_port }}/_xpack/security/user/elastic/_password?pretty"
+    url: "https://{{ current_host_ip }}:{{ elasticsearch_port }}/_security/user/elastic/_password?pretty"
     method: POST
     user: "{{ elasticsearch_username }}"
     password: "{{ initial_elasticsearch_password }}"
@@ -71,7 +71,7 @@
 
 - name: Set kibana password
   uri:
-    url: "https://{{ current_host_ip }}:{{ elasticsearch_port }}/_xpack/security/user/kibana/_password?pretty"
+    url: "https://{{ current_host_ip }}:{{ elasticsearch_port }}/_security/user/kibana/_password?pretty"
     method: POST
     user: "{{ kibana_username }}"
     password: "{{ initial_kibana_password }}"
@@ -83,7 +83,7 @@
 
 - name: Set logstash_system password
   uri:
-    url: "https://{{ current_host_ip }}:{{ elasticsearch_port }}/_xpack/security/user/logstash_system/_password?pretty"
+    url: "https://{{ current_host_ip }}:{{ elasticsearch_port }}/_security/user/logstash_system/_password?pretty"
     method: POST
     user: "{{ logstash_username }}"
     password: "{{ initial_logstash_password }}"


### PR DESCRIPTION
I believe we should stop using the `_xpack/security` endpoint, per the deprecation introduced here: https://github.com/elastic/elasticsearch/pull/36293