### PR TITLE
[Stack Monitoring] Adjust parity test to pull out correct ILM entry

### DIFF
--- a/playbooks/monitoring/elasticsearch/docs_compare.py
+++ b/playbooks/monitoring/elasticsearch/docs_compare.py
@@ -94,7 +94,7 @@ def handle_special_case_cluster_stats(internal_doc, metricbeat_doc):
     # usage stats associated with the Metricbeat-created ILM policy.
     ilm = metricbeat_doc["stack_stats"]["xpack"]["ilm"]
 
-    ilm["policy_stats"].pop()
+    ilm["policy_stats"].pop(1)
     metricbeat_doc["stack_stats"]["xpack"]["ilm"]["policy_stats"] = ilm["policy_stats"]
     metricbeat_doc["stack_stats"]["xpack"]["ilm"]["policy_count"] = ilm["policy_count"] - 1
 


### PR DESCRIPTION
Parity tests began to fail recently and it appears that the problem is that an extra ILM policy is being created. I don't think there is a problem with the parity itself and this is just something that needs to be accounted for in the logic which compares documents. I found that previously, we were just popping off the last document but that this no longer works because the documents are ordered as they previously were.

This simply adjusts the logic to pull out the extra ILM policy from the Metricbeat document in the correct position.

I am not sure of the merge-forward policy in this repo, so this may need a follow-up PR to the master branch after this is reviewed.