### PR TITLE
[7.4] [Stack Monitoring] Implementing diff in parity tests using dictdiffer (#353)

### DIFF
--- a/playbooks/monitoring/beat/docs_compare.py
+++ b/playbooks/monitoring/beat/docs_compare.py
@@ -3,55 +3,6 @@ Usage:
   python docs_compare.py /path/to/internal/docs /path/to/metricbeat/docs
 '''
 
-from docs_compare_util import *
-from jsondiff import diff
-import json
+from docs_compare_util import check_parity
 
-check_usage()
-
-internal_docs_path = get_internal_docs_path()
-metricbeat_docs_path = get_metricbeat_docs_path()
-
-internal_doc_types = get_doc_types(internal_docs_path)
-metricbeat_doc_types = get_doc_types(metricbeat_docs_path)
-
-check_num_doc_types(internal_doc_types, metricbeat_doc_types)
-
-for doc_type in internal_doc_types:
-    internal_doc = get_doc(internal_docs_path, doc_type)
-    metricbeat_doc = get_doc(metricbeat_docs_path, doc_type)
-
-    difference = diff(internal_doc, metricbeat_doc, syntax='explicit', marshal=True)
-
-    # Expect there to be exactly seven top-level insertions to the metricbeat-indexed doc: service, beat, agent, @timestamp, host, event, and metricset
-    allowed_insertions = [ "service", "beat", "agent", "@timestamp", "host", "event", "metricset" ]
-    insertions = difference.get('$insert')
-    if insertions == None or len(insertions) < 1:
-        log_parity_error("Metricbeat-indexed doc for type='" + doc_type + "' has no insertions. Expected up to " + len(allowed_insertions) + " to be inserted.")
-
-    if len(insertions) > len(allowed_insertions):
-        log_parity_error("Metricbeat-indexed doc for type='" + doc_type + "' has too many insertions: " + json.dumps(insertions))
-
-    difference.pop('$insert') 
-
-    # Expect there to be exactly one top-level deletion from metricbeat-indexed doc: source_node
-    deletions = difference.get('$delete')
-    if deletions == None or len(deletions) < 1:
-        log_parity_error("Metricbeat-indexed doc for type='" + doc_type + "' has no deletions. Expected 'source_node' to be deleted.")
-
-    if len(deletions) > 1:
-        log_parity_error("Metricbeat-indexed doc for type='" + doc_type + "' has too many deletions: " + json.dumps(deletions))
-
-    if deletions[0] != 'source_node':
-        log_parity_error("Metricbeat-indexed doc for type='" + doc_type + "' does not have 'source_node' deleted.")
-
-    difference.pop('$delete') 
-
-    # Updates are okay in metricbeat-indexed docs, but insertions and deletions are not
-    if has_insertions_recursive(difference):
-        log_parity_error("Metricbeat-indexed doc for type='" + doc_type + "' has unexpected insertions. Difference: " + json.dumps(difference, indent=2))
-
-    if has_deletions_recursive(difference):
-        log_parity_error("Metricbeat-indexed doc for type='" + doc_type + "' has unexpected deletions. Difference: " + json.dumps(difference, indent=2))
-
-    log_ok("Metricbeat-indexed doc for type='" + doc_type + "' has expected parity with internally-indexed doc.")
+check_parity()

--- a/playbooks/monitoring/common/docs_compare_util.py
+++ b/playbooks/monitoring/common/docs_compare_util.py
@@ -1,6 +1,23 @@
 import os
 import sys
 import json
+from dictdiffer import diff
+
+allowed_insertions_in_metricbeat_docs = [
+  # 'path.to.field'
+  'service',
+  '@timestamp',
+  'agent',
+  'event',
+  'host',
+  'ecs',
+  'metricset'
+]
+
+allowed_deletions_from_metricbeat_docs = [
+  # 'path.to.field'
+  'source_node',
+]
 
 def log_ok(message):
     sys.stdout.write("OK: " + message + "\n")
@@ -10,7 +27,6 @@ def log_error(message):
 
 def log_parity_error(message):
     log_error(message)
-    sys.exit(21)
     
 def check_usage():
   if (len(sys.argv) < 3):
@@ -101,3 +117,75 @@ def has_deletions_recursive(obj):
     else:
         return False
 
+def make_diff_path(diff_path):
+  if isinstance(diff_path, list):
+    path = ''
+    for item in diff_path:
+      path = path + '.' + str(item)
+    return path.strip('.')
+  else:
+    return diff_path
+
+def check_diff(diff_item, allowed_diffs_in_metricbeat_docs):
+  unexpected_diff_paths = []
+
+  diff_parent_path = make_diff_path(diff_item[1])
+  diff_children = diff_item[2]
+
+  for diff_child in diff_children:
+    diff_path = diff_parent_path + '.' + diff_child[0]
+    diff_path = diff_path.strip('.')
+
+    if diff_path not in allowed_diffs_in_metricbeat_docs:
+      unexpected_diff_paths.append(diff_path)
+
+  return unexpected_diff_paths
+
+def check_parity(handle_special_cases = lambda t, i, m: None, allowed_insertions_in_metricbeat_docs_extra = [], allowed_deletions_from_metricbeat_docs_extra = []):
+  allowed_insertions_in_metricbeat_docs.extend(allowed_insertions_in_metricbeat_docs_extra)
+  allowed_deletions_from_metricbeat_docs.extend(allowed_deletions_from_metricbeat_docs_extra)
+
+  check_usage()
+
+  internal_docs_path = get_internal_docs_path()
+  metricbeat_docs_path = get_metricbeat_docs_path()
+
+  internal_doc_types = get_doc_types(internal_docs_path)
+  metricbeat_doc_types = get_doc_types(metricbeat_docs_path)
+
+  check_num_doc_types(internal_doc_types, metricbeat_doc_types)
+
+  num_errors = 0
+  for doc_type in internal_doc_types:
+      internal_doc = get_doc(internal_docs_path, doc_type)
+      metricbeat_doc = get_doc(metricbeat_docs_path, doc_type)
+
+      handle_special_cases(doc_type, internal_doc, metricbeat_doc)
+
+      unexpected_insertions = []
+      unexpected_deletions = []
+      for diff_item in diff(internal_doc, metricbeat_doc):
+        diff_type = diff_item[0]
+
+        if diff_type == 'add':
+          unexpected_insertions.extend(check_diff(diff_item, allowed_insertions_in_metricbeat_docs))
+
+        if diff_type == 'remove':
+          unexpected_deletions.extend(check_diff(diff_item, allowed_deletions_from_metricbeat_docs))
+
+      if len(unexpected_insertions) == 0 and len(unexpected_deletions) == 0:
+        log_ok("Metricbeat-indexed doc for type='" + doc_type + "' has expected parity with internally-indexed doc.")
+        continue
+
+      if len(unexpected_insertions) > 0:
+        for insertion in unexpected_insertions:
+          log_parity_error("Metricbeat-indexed doc for type='" + doc_type + "' has unexpected insertion: " + insertion)
+          num_errors = num_errors + 1
+
+      if len(unexpected_deletions) > 0:
+        for deletion in unexpected_deletions:
+          log_parity_error("Metricbeat-indexed doc for type='" + doc_type + "' has unexpected deletion: " + deletion)
+          num_errors = num_errors + 1
+
+  if num_errors > 0:
+      exit(100 + num_errors)

--- a/playbooks/monitoring/elasticsearch/docs_compare.py
+++ b/playbooks/monitoring/elasticsearch/docs_compare.py
@@ -3,9 +3,7 @@ Usage:
   python docs_compare.py /path/to/internal/docs /path/to/metricbeat/docs
 '''
 
-from docs_compare_util import *
-from jsondiff import diff
-import json
+from docs_compare_util import check_parity
 
 def handle_special_case_index_recovery(internal_doc, metricbeat_doc):
     # Normalize `index_recovery.shards` array field to have only one object in it.
@@ -13,15 +11,41 @@ def handle_special_case_index_recovery(internal_doc, metricbeat_doc):
     metricbeat_doc["index_recovery"]["shards"] = [ metricbeat_doc["index_recovery"]["shards"][0] ]
 
 def handle_special_case_cluster_stats(internal_doc, metricbeat_doc):
+    # We expect the node ID to be different in the internally-collected vs. metricbeat-collected
+    # docs because the tests spin up a fresh 1-node cluster prior to each type of collection.
+    # So we normalize the node names.
+    new_node_name = '__normalized__'
+
+    orig_node_name = internal_doc['cluster_state']['master_node']
+    internal_doc['cluster_state']['master_node'] = new_node_name
+    internal_doc['cluster_state']['nodes'][new_node_name] = internal_doc['cluster_state']['nodes'][orig_node_name]
+    del internal_doc['cluster_state']['nodes'][orig_node_name]
+
+    orig_node_name = metricbeat_doc['cluster_state']['master_node']
+    metricbeat_doc['cluster_state']['master_node'] = new_node_name
+    metricbeat_doc['cluster_state']['nodes'][new_node_name] = metricbeat_doc['cluster_state']['nodes'][orig_node_name]
+    del metricbeat_doc['cluster_state']['nodes'][orig_node_name]
+
     # When Metricbeat-based monitoring is used, Metricbeat will setup an ILM policy for
     # metricbeat-* indices. Obviously this policy is not present when internal monitoring is
     # used, since Metricbeat is not running in that case. So we normalize by removing the
     # usage stats associated with the Metricbeat-created ILM policy.
-    ilm = metricbeat_doc["stack_stats"]["xpack"]["ilm"]
+    policy_stats = metricbeat_doc["stack_stats"]["xpack"]["ilm"]["policy_stats"]
 
-    ilm["policy_stats"].pop(1)
-    metricbeat_doc["stack_stats"]["xpack"]["ilm"]["policy_stats"] = ilm["policy_stats"]
-    metricbeat_doc["stack_stats"]["xpack"]["ilm"]["policy_count"] = ilm["policy_count"] - 1
+    # The Metricbeat ILM policy is the one with exactly one phase: hot
+    new_policy_stats = []
+    for policy_stat in policy_stats:
+      policy_phases = list(policy_stat["phases"].keys())
+      num_phases = len(policy_phases)
+      if num_phases != 1:
+        new_policy_stats.append(policy_stat)
+        continue
+      if policy_phases[0] != 'hot':
+        new_policy_stats.append(policy_stat)
+        continue
+
+    metricbeat_doc["stack_stats"]["xpack"]["ilm"]["policy_stats"] = new_policy_stats
+    metricbeat_doc["stack_stats"]["xpack"]["ilm"]["policy_count"] = len(new_policy_stats)
 
 def handle_special_case_node_stats(internal_doc, metricbeat_doc):
     # Metricbeat-indexed docs of `type:node_stats` fake the `source_node` field since its required
@@ -65,54 +89,4 @@ def handle_special_cases(doc_type, internal_doc, metricbeat_doc):
     if doc_type == 'shards':
         handle_special_case_shards(internal_doc, metricbeat_doc)
 
-
-check_usage()
-
-internal_docs_path = get_internal_docs_path()
-metricbeat_docs_path = get_metricbeat_docs_path()
-
-internal_doc_types = get_doc_types(internal_docs_path)
-metricbeat_doc_types = get_doc_types(metricbeat_docs_path)
-
-check_num_doc_types(internal_doc_types, metricbeat_doc_types)
-
-for doc_type in internal_doc_types:
-    internal_doc = get_doc(internal_docs_path, doc_type)
-    metricbeat_doc = get_doc(metricbeat_docs_path, doc_type)
-
-    handle_special_cases(doc_type, internal_doc, metricbeat_doc)
-
-    difference = diff(internal_doc, metricbeat_doc, syntax='explicit', marshal=True)
-
-    # Expect there to be exactly seven top-level insertions to the metricbeat-indexed doc: service, ecs, agent, @timestamp, host, event, and metricset
-    allowed_insertions = [ "service", "ecs", "agent", "@timestamp", "host", "event", "metricset" ]
-    insertions = difference.get('$insert')
-    if insertions == None or len(insertions) < 1:
-        log_parity_error("Metricbeat-indexed doc for type='" + doc_type + "' has no insertions. Expected 'beat', '@timestamp', 'host', and 'metricset' to be inserted.")
-
-    if len(insertions) > len(allowed_insertions):
-        log_parity_error("Metricbeat-indexed doc for type='" + doc_type + "' has too many insertions: " + json.dumps(insertions))
-
-    difference.pop('$insert') 
-
-    # Expect there to be exactly one top-level deletion from metricbeat-indexed doc - the `source_node` field - except
-    # if the doc type is `node_stats` or `shards`. Those doc types are expected to contain the `source_node` field
-    if doc_type != 'node_stats' and doc_type != 'shards':
-        deletions = difference.get('$delete')
-        if deletions == None or len(deletions) < 1:
-          # All other types should have source_node deleted from Metricbeat-indexed docs.
-          log_parity_error("Metricbeat-indexed doc for type='" + doc_type + "' has no deletions. Expected 'source_node' to be deleted.")
-
-        if len(deletions) > 1:
-            log_parity_error("Metricbeat-indexed doc for type='" + doc_type + "' has too many deletions: " + json.dumps(deletions))
-
-        difference.pop('$delete') 
-
-    # Updates are okay in metricbeat-indexed docs, but insertions and deletions are not
-    if has_insertions_recursive(difference):
-        log_parity_error("Metricbeat-indexed doc for type='" + doc_type + "' has unexpected insertions. Difference: " + json.dumps(difference, indent=2))
-
-    if has_deletions_recursive(difference):
-        log_parity_error("Metricbeat-indexed doc for type='" + doc_type + "' has unexpected deletions. Difference: " + json.dumps(difference, indent=2))
-
-    log_ok("Metricbeat-indexed doc for type='" + doc_type + "' has expected parity with internally-indexed doc.")
+check_parity(handle_special_cases)

--- a/playbooks/monitoring/kibana/docs_compare.py
+++ b/playbooks/monitoring/kibana/docs_compare.py
@@ -3,62 +3,26 @@ Usage:
   python docs_compare.py /path/to/internal/docs /path/to/metricbeat/docs
 '''
 
-from docs_compare_util import *
-from jsondiff import diff
-import json
+from docs_compare_util import check_parity
 
-check_usage()
+allowed_deletions_from_metricbeat_docs_extra = [
+  # 'path.to.field'
+  'kibana_stats.response_times.max',
+  'kibana_stats.response_times.average'
+]
 
-internal_docs_path = get_internal_docs_path()
-metricbeat_docs_path = get_metricbeat_docs_path()
+def handle_special_case_kibana_settings(internal_doc, metricbeat_doc):
+  # Internal collection will index kibana_settings.xpack.default_admin_email as null
+  # whereas Metricbeat collection simply won't index it. So if we find kibana_settings.xpack.default_admin_email 
+  # is null, we simply remove it
+  if "xpack" in internal_doc["kibana_settings"] \
+    and "default_admin_email" in internal_doc["kibana_settings"]["xpack"] \
+    and internal_doc["kibana_settings"]["xpack"]["default_admin_email"] == None:
+    internal_doc["kibana_settings"]["xpack"].pop("default_admin_email")
 
-internal_doc_types = get_doc_types(internal_docs_path)
-metricbeat_doc_types = get_doc_types(metricbeat_docs_path)
+def handle_special_cases(doc_type, internal_doc, metricbeat_doc):
+    if doc_type == "kibana_settings":
+        handle_special_case_kibana_settings(internal_doc, metricbeat_doc)
 
-check_num_doc_types(internal_doc_types, metricbeat_doc_types)
 
-for doc_type in internal_doc_types:
-    internal_doc = get_doc(internal_docs_path, doc_type)
-    metricbeat_doc = get_doc(metricbeat_docs_path, doc_type)
-
-    # Certain fields are expected to be optional, as they depend on the time of collection. We omit those from the comparison.
-    optional_fields = [
-        "kibana_stats.response_times.average"
-    ]
-    remove_optional_fields(internal_doc, optional_fields)
-    remove_optional_fields(metricbeat_doc, optional_fields)
-
-    difference = diff(internal_doc, metricbeat_doc, syntax='explicit', marshal=True)
-
-    # Expect there to be exactly seven top-level insertions to the metricbeat-indexed doc: service, beat, agent, @timestamp, host, event, and metricset
-    allowed_insertions = [ "service", "beat", "agent", "@timestamp", "host", "event", "metricset" ]
-    insertions = difference.get('$insert')
-    if insertions == None or len(insertions) < 1:
-        log_parity_error("Metricbeat-indexed doc for type='" + doc_type + "' has no insertions. Expected up to " + len(allowed_insertions) + " to be inserted.")
-
-    if len(insertions) > len(allowed_insertions):
-        log_parity_error("Metricbeat-indexed doc for type='" + doc_type + "' has too many insertions: " + json.dumps(insertions))
-
-    difference.pop('$insert') 
-
-    # Expect there to be exactly one top-level deletion from metricbeat-indexed doc: source_node
-    deletions = difference.get('$delete')
-    if deletions == None or len(deletions) < 1:
-        log_parity_error("Metricbeat-indexed doc for type='" + doc_type + "' has no deletions. Expected 'source_node' to be deleted.")
-
-    if len(deletions) > 1:
-        log_parity_error("Metricbeat-indexed doc for type='" + doc_type + "' has too many deletions: " + json.dumps(deletions))
-
-    if deletions[0] != 'source_node':
-        log_parity_error("Metricbeat-indexed doc for type='" + doc_type + "' does not have 'source_node' deleted.")
-
-    difference.pop('$delete') 
-
-    # Updates are okay in metricbeat-indexed docs, but insertions and deletions are not
-    if has_insertions_recursive(difference):
-        log_parity_error("Metricbeat-indexed doc for type='" + doc_type + "' has unexpected insertions. Difference: " + json.dumps(difference, indent=2))
-
-    if has_deletions_recursive(difference):
-        log_parity_error("Metricbeat-indexed doc for type='" + doc_type + "' has unexpected deletions. Difference: " + json.dumps(difference, indent=2))
-
-    log_ok("Metricbeat-indexed doc for type='" + doc_type + "' has expected parity with internally-indexed doc.")
+check_parity(handle_special_cases, allowed_deletions_from_metricbeat_docs_extra=allowed_deletions_from_metricbeat_docs_extra)

--- a/playbooks/monitoring/logstash/docs_compare.py
+++ b/playbooks/monitoring/logstash/docs_compare.py
@@ -3,9 +3,7 @@ Usage:
   python docs_compare.py /path/to/internal/docs /path/to/metricbeat/docs
 '''
 
-from docs_compare_util import *
-from jsondiff import diff
-import json
+from docs_compare_util import check_parity
 
 def handle_special_case_logstash_stats(internal_doc, metricbeat_doc):
     # Normalize `logstash_stats.pipelines[0].vertices` array in both docs to be sorted by vertex ID
@@ -16,53 +14,4 @@ def handle_special_cases(doc_type, internal_doc, metricbeat_doc):
     if doc_type == "logstash_stats":
         handle_special_case_logstash_stats(internal_doc, metricbeat_doc)
 
-check_usage()
-
-internal_docs_path = get_internal_docs_path()
-metricbeat_docs_path = get_metricbeat_docs_path()
-
-internal_doc_types = get_doc_types(internal_docs_path)
-metricbeat_doc_types = get_doc_types(metricbeat_docs_path)
-
-check_num_doc_types(internal_doc_types, metricbeat_doc_types)
-
-for doc_type in internal_doc_types:
-    internal_doc = get_doc(internal_docs_path, doc_type)
-    metricbeat_doc = get_doc(metricbeat_docs_path, doc_type)
-
-    handle_special_cases(doc_type, internal_doc, metricbeat_doc)
-
-    difference = diff(internal_doc, metricbeat_doc, syntax='explicit', marshal=True)
-
-    # Expect there to be exactly seven top-level insertions to the metricbeat-indexed doc: service, beat, agent, @timestamp, host, event, and metricset
-    allowed_insertions = [ "service", "ecs", "agent", "@timestamp", "host", "event", "metricset" ]
-    insertions = difference.get('$insert')
-    if insertions == None or len(insertions) < 1:
-        log_parity_error("Metricbeat-indexed doc for type='" + doc_type + "' has no insertions. Expected 'beat', '@timestamp', 'host', and 'metricset' to be inserted.")
-
-    if len(insertions) > len(allowed_insertions):
-        log_parity_error("Metricbeat-indexed doc for type='" + doc_type + "' has too many insertions: " + json.dumps(insertions))
-
-    difference.pop('$insert') 
-
-    # Expect there to be exactly one top-level deletion from metricbeat-indexed doc: source_node
-    deletions = difference.get('$delete')
-    if deletions == None or len(deletions) < 1:
-        log_parity_error("Metricbeat-indexed doc for type='" + doc_type + "' has no deletions. Expected 'source_node' to be deleted.")
-
-    if len(deletions) > 1:
-        log_parity_error("Metricbeat-indexed doc for type='" + doc_type + "' has too many deletions: " + json.dumps(deletions))
-
-    if deletions[0] != 'source_node':
-        log_parity_error("Metricbeat-indexed doc for type='" + doc_type + "' does not have 'source_node' deleted.")
-
-    difference.pop('$delete') 
-
-    # Updates are okay in metricbeat-indexed docs, but insertions and deletions are not
-    if has_insertions_recursive(difference):
-        log_parity_error("Metricbeat-indexed doc for type='" + doc_type + "' has unexpected insertions. Difference: " + json.dumps(difference, indent=2))
-
-    if has_deletions_recursive(difference):
-        log_parity_error("Metricbeat-indexed doc for type='" + doc_type + "' has unexpected deletions. Difference: " + json.dumps(difference, indent=2))
-
-    log_ok("Metricbeat-indexed doc for type='" + doc_type + "' has expected parity with internally-indexed doc.")
+check_parity(handle_special_cases)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ pytest===3.2.2
 selenium==3.5.0
 webium==1.2.1
 xvfbwrapper==0.2.9
-jsondiff==1.1.2
+dictdiffer==0.8.0


### PR DESCRIPTION
Backports the following commits to 7.4:
 - [Stack Monitoring] Implementing diff in parity tests using dictdiffer  (#353)