### PR TITLE
Debugging: print all kibana_stats docs indexed by Metricbeat

### DIFF
--- a/playbooks/monitoring/kibana/docs_parity.yml
+++ b/playbooks/monitoring/kibana/docs_parity.yml
@@ -154,7 +154,8 @@
         user: "{{ elasticsearch_username }}"
         password: "{{ elasticsearch_password }}"
         method: POST
-        body: '{ "collapse": { "field": "type" }, "sort": { "timestamp": "asc" } }'
+        # body: '{ "collapse": { "field": "type" }, "sort": { "timestamp": "asc" } }'
+        body: '{ "query": { "term": { "type": "kibana_stats" } }, "_source": [ "timestamp", "kibana_stats" ] }'
         body_format: json
         status_code: 200
       register: xpack_elasticsearch_monitoring_sample_docs


### PR DESCRIPTION
For the [past several runs](https://internal-ci.elastic.co/job/elastic+estf-monitoring-snapshots+6.8+multijob-kibana/), Stack Monitoring parity tests for Kibana are failing consistently in CI on the `6.8` branch with this error:

```
09:45:24 *** Internally-indexed doc for type='kibana_stats': ***
09:45:24 {'timestamp': '2019-09-30T16:44:43.141Z', 'cluster_uuid': 'xsoEte8rQ2mhs7nULlEtsw', 'interval_ms': 10000, 'kibana_stats': {'response_times': {'max': 0, 'average': 0}, 'process': {'event_loop_delay': 0.9391340000147466, 'memory': {'resident_set_size_in_bytes': 361537536, 'heap': {'size_limit': 1526909922, 'total_in_bytes': 255574016, 'used_in_bytes': 161960000}}, 'uptime_in_millis': 22992}, 'timestamp': '2019-09-30T16:44:42.947Z', 'kibana': {'status': 'green', 'index': '.kibana', 'transport_address': '10.0.2.15:5601', 'uuid': 'd19dca06-1379-43fe-9eb7-8ab8ea410a32', 'host': '10.0.2.15', 'version': '6.8.4', 'snapshot': True, 'name': 'packer-virtualbox-iso-1569167285'}, 'usage': {'index': '.kibana', 'search': {'total': 0}, 'xpack': {'reporting': {'available': True, '_all': 0, 'browser_type': 'chromium', 'last7Days': {'_all': 0, 'status': {}, 'printable_pdf': {'available': True, 'app': {'visualization': 0, 'dashboard': 0}, 'total': 0, 'layout': {'print': 0, 'preserve_layout': 0}}, 'csv': {'available': True, 'total': 0}, 'PNG': {'available': True, 'total': 0}}, 'enabled': True, 'printable_pdf': {'available': True, 'app': {'visualization': 0, 'dashboard': 0}, 'total': 0, 'layout': {'print': 0, 'preserve_layout': 0}}, 'status': {}, 'lastDay': {'_all': 0, 'status': {}, 'printable_pdf': {'available': True, 'app': {'visualization': 0, 'dashboard': 0}, 'total': 0, 'layout': {'print': 0, 'preserve_layout': 0}}, 'csv': {'available': True, 'total': 0}, 'PNG': {'available': True, 'total': 0}}, 'csv': {'available': True, 'total': 0}, 'PNG': {'available': True, 'total': 0}}}, 'visualization': {'total': 0}, 'ml': {'file_data_visualizer': {'index_creation_count': 0}}, 'rollups': {'index_patterns': {'total': 0}, 'visualizations': {'saved_searches': {'total': 0}, 'total': 0}, 'saved_searches': {'total': 0}}, 'localization': {'locale': 'en', 'labelsCount': 0, 'integrities': {}}, 'maps': {'attributesPerMap': {'layersCount': {'max': 0, 'avg': 0, 'min': 0}, 'dataSourcesCount': {'max': 0, 'avg': 0, 'min': 0}, 'layerTypesCount': {}, 'emsVectorLayersCount': {}}, 'mapsTotalCount': 0, 'timeCaptured': '2019-09-30T16:44:34.840Z'}, 'infraops': {'last_24_hours': {'hits': {'infraops_hosts': 0, 'infraops_docker': 0, 'infraops_kubernetes': 0, 'logs': 0}}}, 'spaces': {'available': True, 'count': 1, 'enabled': True}, 'dashboard': {'total': 0}, 'apm': {'services_per_agent': {}, 'has_any_services': False}, 'graph_workspace': {'total': 0}, 'index_pattern': {'total': 0}, 'timelion_sheet': {'total': 0}, 'upgrade-assistant-telemetry': {'ui_reindex': {'close': 0, 'stop': 0, 'open': 0, 'start': 0}, 'features': {'deprecation_logging': {'enabled': True}}, 'ui_open': {'indices': 0, 'overview': 0, 'cluster': 0}}, 'cloud': {'isCloudEnabled': False}, 'kql': {'optInCount': 0, 'defaultQueryLanguage': 'default-lucene', 'optOutCount': 0}}, 'requests': {'disconnects': 0, 'total': 0}, 'concurrent_connections': 0, 'os': {'load': {'5m': 0.18505859375, '1m': 0.55078125, '15m': 0.0625}, 'memory': {'free_in_bytes': 329904128, 'total_in_bytes': 4143374336, 'used_in_bytes': 3813470208}, 'uptime_in_millis': 123000, 'platform': 'linux', 'distroRelease': 'Ubuntu Linux-16.04', 'platformRelease': 'linux-4.4.0-164-generic', 'distro': 'Ubuntu Linux'}}, 'type': 'kibana_stats', 'source_node': {'transport_address': '10.0.2.15:9300', 'uuid': 'OXzWeLtOQZ-pa461nw9gfg', 'ip': '10.0.2.15', 'host': '10.0.2.15', 'timestamp': '2019-09-30T16:44:43.144Z', 'name': 'OXzWeLt'}}
09:45:24 *** Metricbeat-indexed doc for type='kibana_stats': ***
09:45:24 {'beat': {'hostname': 'packer-virtualbox-iso-1569167285', 'name': 'packer-virtualbox-iso-1569167285', 'version': '6.8.4'}, 'timestamp': '2019-09-30T16:45:13.938Z', '@timestamp': '2019-09-30T16:45:13.938Z', 'event': {'duration': 31819411, 'dataset': 'kibana.stats'}, 'cluster_uuid': 'xsoEte8rQ2mhs7nULlEtsw', 'host': {'architecture': 'x86_64', 'os': {'platform': 'ubuntu', 'codename': 'xenial', 'version': '16.04.6 LTS (Xenial Xerus)', 'name': 'Ubuntu', 'family': 'debian'}, 'id': 'b59022598a4efae4e29317a25d87987a', 'containerized': False, 'name': 'packer-virtualbox-iso-1569167285'}, 'interval_ms': 10000, 'kibana_stats': {'response_times': {'max': 0}, 'process': {'event_loop_delay': 0.07384300002013333, 'memory': {'resident_set_size_in_bytes': 319758336, 'heap': {'size_limit': 1526909922, 'total_in_bytes': 210440192, 'used_in_bytes': 169678000}}, 'uptime_in_millis': 16683}, 'timestamp': '2019-09-30T16:45:13.938Z', 'kibana': {'status': 'green', 'index': '.kibana', 'transport_address': '10.0.2.15:5601', 'uuid': 'd19dca06-1379-43fe-9eb7-8ab8ea410a32', 'host': '10.0.2.15', 'version': '6.8.4', 'snapshot': True, 'name': 'packer-virtualbox-iso-1569167285'}, 'usage': {}, 'requests': {'disconnects': 0, 'total': 0}, 'concurrent_connections': 0, 'os': {'load': {'5m': 0.27978515625, '15m': 0.0986328125, '1m': 0.80419921875}, 'memory': {'free_in_bytes': 221356032, 'used_in_bytes': 3922018304, 'total_in_bytes': 4143374336}, 'uptime_in_millis': 153000, 'platform': 'linux', 'distroRelease': 'Ubuntu Linux-16.04', 'platformRelease': 'linux-4.4.0-164-generic', 'distro': 'Ubuntu Linux'}}, 'type': 'kibana_stats', 'metricset': {'rtt': 31819, 'host': '10.0.2.15:5601', 'name': 'stats', 'module': 'kibana'}}
09:45:24 
09:45:24 
09:45:24 STDERR:
09:45:24 
09:45:24 ERROR: Metricbeat-indexed doc for type='kibana_stats' has unexpected deletion: kibana_stats.usage.index
09:45:24 ERROR: Metricbeat-indexed doc for type='kibana_stats' has unexpected deletion: kibana_stats.usage.search
09:45:24 ERROR: Metricbeat-indexed doc for type='kibana_stats' has unexpected deletion: kibana_stats.usage.xpack
09:45:24 ERROR: Metricbeat-indexed doc for type='kibana_stats' has unexpected deletion: kibana_stats.usage.visualization
09:45:24 ERROR: Metricbeat-indexed doc for type='kibana_stats' has unexpected deletion: kibana_stats.usage.ml
09:45:24 ERROR: Metricbeat-indexed doc for type='kibana_stats' has unexpected deletion: kibana_stats.usage.rollups
09:45:24 ERROR: Metricbeat-indexed doc for type='kibana_stats' has unexpected deletion: kibana_stats.usage.localization
09:45:24 ERROR: Metricbeat-indexed doc for type='kibana_stats' has unexpected deletion: kibana_stats.usage.maps
09:45:24 ERROR: Metricbeat-indexed doc for type='kibana_stats' has unexpected deletion: kibana_stats.usage.infraops
09:45:24 ERROR: Metricbeat-indexed doc for type='kibana_stats' has unexpected deletion: kibana_stats.usage.spaces
09:45:24 ERROR: Metricbeat-indexed doc for type='kibana_stats' has unexpected deletion: kibana_stats.usage.dashboard
09:45:24 ERROR: Metricbeat-indexed doc for type='kibana_stats' has unexpected deletion: kibana_stats.usage.apm
09:45:24 ERROR: Metricbeat-indexed doc for type='kibana_stats' has unexpected deletion: kibana_stats.usage.graph_workspace
09:45:24 ERROR: Metricbeat-indexed doc for type='kibana_stats' has unexpected deletion: kibana_stats.usage.index_pattern
09:45:24 ERROR: Metricbeat-indexed doc for type='kibana_stats' has unexpected deletion: kibana_stats.usage.timelion_sheet
09:45:24 ERROR: Metricbeat-indexed doc for type='kibana_stats' has unexpected deletion: kibana_stats.usage.upgrade-assistant-telemetry
09:45:24 ERROR: Metricbeat-indexed doc for type='kibana_stats' has unexpected deletion: kibana_stats.usage.cloud
09:45:24 ERROR: Metricbeat-indexed doc for type='kibana_stats' has unexpected deletion: kibana_stats.usage.kql
```

However, the same tests pass locally (for me anyway) even after running them multiple times.

In order to debug the issue in the CI environment, this PR queries **all** `type: kibana_stats` documents indexed by Metricbeat. We should see the result of this query in the CI job's log. I'm hoping it will show us whether there are _any_ `type: kibana_stats` documents with a non-empty `kibana_stats.usage` field.