### PR TITLE
[7.3] Add missing pprint (#397)

### DIFF
--- a/playbooks/monitoring/common/docs_compare_util.py
+++ b/playbooks/monitoring/common/docs_compare_util.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import json
+import pprint
 from dictdiffer import diff
 
 allowed_insertions_in_metricbeat_docs = [


### PR DESCRIPTION
Backports the following commits to 7.3:
 - Add missing pprint (#397)