### PR TITLE
Except several kibana fields

### DIFF
--- a/playbooks/monitoring/kibana/docs_compare.py
+++ b/playbooks/monitoring/kibana/docs_compare.py
@@ -8,7 +8,11 @@ from docs_compare_util import check_parity
 allowed_deletions_from_metricbeat_docs_extra = [
   # 'path.to.field'
   'kibana_stats.response_times.max',
-  'kibana_stats.response_times.average'
+  'kibana_stats.response_times.average',
+  'kibana_stats.usage.visualization_types',
+  'kibana_stats.usage.maps.attributesPerMap',
+  'kibana_stats.usage.maps.mapsTotalCount',
+  'kibana_stats.usage.maps.timeCaptured'
 ]
 
 def handle_special_case_kibana_settings(internal_doc, metricbeat_doc):


### PR DESCRIPTION
This adds exceptions to the following fields in Kibana comparisons:

- kibana_stats.usage.visualization_types
- kibana_stats.usage.maps.attributesPerMap
- kibana_stats.usage.maps.mapsTotalCount
- kibana_stats.usage.maps.timeCaptured

None of these fields appear to be in use in the monitoring application but do appear to be in use by telemetry. So, this begs the question of whether or not we should maintain parity between metricbeat and fields used in telemetry. While I don't think parity should be necessary as telemetry should be responsible for continuing to deliver data as it always has, I don't recall a discussion in which this point was specifically discussed so I'm raising it here in case I'm mistaken.
