### PR TITLE
Add enrich metricset to elasticsearch metricbeat module configuration

### DIFF
--- a/playbooks/monitoring/buildenv.sh
+++ b/playbooks/monitoring/buildenv.sh
@@ -6,7 +6,7 @@
 export AIT_RUN_LOCAL=true
 
 # Build URL
-export ES_BUILD_URL=
+export ES_BUILD_URL=snapshots.elastic.co/8.0.0-4b028b4b
 
 # Build Type 
 export ES_BUILD_OSS=false


### PR DESCRIPTION
With the introduction of https://github.com/elastic/beats/pull/14243 it is necessary to write out configurations which contain the `enrich` metricset. This corrects Elasticsearch parity test failures which are happening currently, such as this one: https://internal-ci.elastic.co/job/elastic+estf-monitoring-snapshots+master+multijob-elasticsearch/72/consoleFull