### PR TITLE
Add enrich metricset to elasticsearch metricbeat module configuration

### DIFF
--- a/playbooks/monitoring/elasticsearch/docs_parity.yml
+++ b/playbooks/monitoring/elasticsearch/docs_parity.yml
@@ -136,6 +136,7 @@
             - ml_job
             - node_stats
             - shard
+            - enrich
             period: 10s
             hosts: ["https://{{ current_host_ip }}:{{ elasticsearch_port }}"]
             ssl.verification_mode: none


### PR DESCRIPTION
With the introduction of elastic/beats#14243 it is necessary to write out configurations which contain the enrich metricset. This corrects Elasticsearch parity test failures which are happening currently, such as this one: https://internal-ci.elastic.co/job/elastic+estf-monitoring-snapshots+master+multijob-elasticsearch/72/consoleFull