### PR TITLE
Clean out .kibana_* indexes before restarting kibana

### DIFF
--- a/playbooks/monitoring/kibana/docs_parity.yml
+++ b/playbooks/monitoring/kibana/docs_parity.yml
@@ -91,6 +91,15 @@
         password: "{{ elasticsearch_password }}"
         status_code: 200
 
+    - name: Clean out kibana indexes from Elasticsearch
+      uri:
+        method: DELETE
+        url: "https://{{ current_host_ip }}:{{ elasticsearch_port }}/.kibana_*"
+        validate_certs: no
+        user: "{{ elasticsearch_username }}"
+        password: "{{ elasticsearch_password }}"
+        status_code: 200
+
     - name: Start kibana
       include_role:
         name: kibana


### PR DESCRIPTION
This resolves [the following error](https://internal-ci.elastic.co/job/elastic+estf-monitoring-snapshots+7.4+multijob-kibana/78/consoleFull):

`ERROR: Metricbeat-indexed doc for type='kibana_stats' has unexpected deletion: kibana_stats.usage.visualization_types`

The above error also [appeared recently here](https://internal-ci.elastic.co/job/elastic+estf-monitoring-snapshots+7.4+multijob-kibana/68/console).

I was receiving this error consistently in my testing on the 7.4 branch but after applying this fix, I can no longer produce the error after multiple tests runs.

I have a hunch (but cannot definitively prove) that this may resolve [other flaky tests](https://internal-ci.elastic.co/job/elastic+estf-monitoring-snapshots+7.4+multijob-kibana/74/console) wherein `kibana_stats` documents do not contain certain `usage` fields.

Related to the reason that this seems to happen is that Kibana will return warnings on startup for certain collectors if "duplicate documents" are found. Below are some examples:

```
server    log   [15:16:21.949] [warning][telemetry] Error scheduling task, received [task:oss_telemetry-vis_telemetry]: version conflict, document already exists (current version [3]): [version_conflict_engine_exception] [task:oss_telemetry-vis_telemetry]: version conflict, document already exists (current version [3]), with { index_uuid="4kgae7-8Rx6mWE5QAHhqkA" & shard="0" & index=".kibana_task_manager_1" }
server    log   [15:16:21.950] [debug][admin][elasticsearch][query] 409
```

```
server    log   [15:16:21.952] [warning][maps] Error scheduling telemetry task, received [task:Maps-maps_telemetry]: version conflict, document already exists (current version [3]): [version_conflict_engine_exception] [task:Maps-maps_telemetry]: version conflict, document already exists (current version [3]), with { index_uuid="4kgae7-8Rx6mWE5QAHhqkA" & shard="0" & index=".kibana_task_manager_1" }
```