### PR TITLE
[7.x] Replace references to "internal" with "legacy" (#549)

### DIFF
--- a/playbooks/monitoring/beat/docs_compare.py
+++ b/playbooks/monitoring/beat/docs_compare.py
@@ -1,27 +1,27 @@
 '''
 Usage:
-  python docs_compare.py /path/to/internal/docs /path/to/metricbeat/docs
+  python docs_compare.py /path/to/legacy/docs /path/to/metricbeat/docs
 '''
 
 from docs_compare_util import check_parity
 
-def handle_special_case_beats_stats(internal_doc, metricbeat_doc):
+def handle_special_case_beats_stats(legacy_doc, metricbeat_doc):
   # When Metricbeat monitors Filebeat, it encounters a different set of file IDs in 
-  # `type:beats_stats` documents than when internal collection monitors Filebeat. However,
+  # `type:beats_stats` documents than when legacy collection monitors Filebeat. However,
   # we expect the _number_ of files being harvested by Filebeat in either case to match. 
   # If the numbers match we normalize the file lists in `type:beats_stats` docs collected
   # by both methods so their parity comparison succeeds.
-  internal_files = internal_doc["beats_stats"]["metrics"]["filebeat"]["harvester"]["files"]
+  legacy_files = legacy_doc["beats_stats"]["metrics"]["filebeat"]["harvester"]["files"]
   metricbeat_files = metricbeat_doc["beats_stats"]["metrics"]["filebeat"]["harvester"]["files"]
 
-  if len(internal_files) != len(metricbeat_files):
+  if len(legacy_files) != len(metricbeat_files):
     return
 
-  internal_doc["beats_stats"]["metrics"]["filebeat"]["harvester"]["files"] = []
+  legacy_doc["beats_stats"]["metrics"]["filebeat"]["harvester"]["files"] = []
   metricbeat_doc["beats_stats"]["metrics"]["filebeat"]["harvester"]["files"] = []
 
-def handle_special_cases(doc_type, internal_doc, metricbeat_doc):
+def handle_special_cases(doc_type, legacy_doc, metricbeat_doc):
   if doc_type == "beats_stats":
-    handle_special_case_beats_stats(internal_doc, metricbeat_doc)
+    handle_special_case_beats_stats(legacy_doc, metricbeat_doc)
 
 check_parity(handle_special_cases)

--- a/playbooks/monitoring/beat/docs_parity.yml
+++ b/playbooks/monitoring/beat/docs_parity.yml
@@ -1,5 +1,5 @@
 #----------------------------------------------------------------------------------------------------------------------
-# Playbook: Test for parity between metricbeat-indexed and internally-indexed Monitoring docs
+# Playbook: Test for parity between metricbeat-indexed and legacy-indexed Monitoring docs
 #
 # Author: shaunak@elastic.co
 #----------------------------------------------------------------------------------------------------------------------
@@ -29,7 +29,7 @@
         state: directory
         path: "{{ monitoring_docs_dir }}/beat/{{ item }}/"
       with_items:
-        - internal
+        - legacy
         - metricbeat
       delegate_to: localhost
 
@@ -40,7 +40,7 @@
         elasticsearch_config_params: {"xpack.monitoring.collection.enabled: true"}
         ait_role: xpack_elasticsearch_install_gencert_config_start_verify
 
-    - name: Run filebeat with internal collection
+    - name: Run filebeat with legacy collection
       include_role:
         name: xpack_filebeat
       vars:
@@ -68,7 +68,7 @@
     - name: Write sample docs to temp files
       copy:
         content: "{{ item._source }}"
-        dest: "{{ monitoring_docs_dir }}/beat/internal/{{ item._source.type }}.json"
+        dest: "{{ monitoring_docs_dir }}/beat/legacy/{{ item._source.type }}.json"
       with_items: "{{ xpack_elasticsearch_monitoring_sample_docs.json.hits.hits }}"
       delegate_to: localhost
 
@@ -171,6 +171,6 @@
       vars:
         ait_action: elasticsearch_shutdown
 
-    - name: Compare internally-indexed and metricbeat-indexed documents for parity
-      shell: 'python {{ playbook_dir }}/docs_compare.py {{ monitoring_docs_dir }}/beat/internal {{ monitoring_docs_dir }}/beat/metricbeat'
+    - name: Compare legacy-indexed and metricbeat-indexed documents for parity
+      shell: 'python {{ playbook_dir }}/docs_compare.py {{ monitoring_docs_dir }}/beat/legacy {{ monitoring_docs_dir }}/beat/metricbeat'
       delegate_to: localhost

--- a/playbooks/monitoring/elasticsearch/docs_compare.py
+++ b/playbooks/monitoring/elasticsearch/docs_compare.py
@@ -1,24 +1,24 @@
 '''
 Usage:
-  python docs_compare.py /path/to/internal/docs /path/to/metricbeat/docs
+  python docs_compare.py /path/to/legacy/docs /path/to/metricbeat/docs
 '''
 from docs_compare_util import check_parity
 
-def handle_special_case_index_recovery(internal_doc, metricbeat_doc):
+def handle_special_case_index_recovery(legacy_doc, metricbeat_doc):
     # Normalize `index_recovery.shards` array field to have only one object in it.
-    internal_doc["index_recovery"]["shards"] = [ internal_doc["index_recovery"]["shards"][0] ]
+    legacy_doc["index_recovery"]["shards"] = [ legacy_doc["index_recovery"]["shards"][0] ]
     metricbeat_doc["index_recovery"]["shards"] = [ metricbeat_doc["index_recovery"]["shards"][0] ]
 
-def handle_special_case_cluster_stats(internal_doc, metricbeat_doc):
-    # We expect the node ID to be different in the internally-collected vs. metricbeat-collected
+def handle_special_case_cluster_stats(legacy_doc, metricbeat_doc):
+    # We expect the node ID to be different in the legacy-collected vs. metricbeat-collected
     # docs because the tests spin up a fresh 1-node cluster prior to each type of collection.
     # So we normalize the node names.
     new_node_name = '__normalized__'
 
-    orig_node_name = internal_doc['cluster_state']['master_node']
-    internal_doc['cluster_state']['master_node'] = new_node_name
-    internal_doc['cluster_state']['nodes'][new_node_name] = internal_doc['cluster_state']['nodes'][orig_node_name]
-    del internal_doc['cluster_state']['nodes'][orig_node_name]
+    orig_node_name = legacy_doc['cluster_state']['master_node']
+    legacy_doc['cluster_state']['master_node'] = new_node_name
+    legacy_doc['cluster_state']['nodes'][new_node_name] = legacy_doc['cluster_state']['nodes'][orig_node_name]
+    del legacy_doc['cluster_state']['nodes'][orig_node_name]
 
     orig_node_name = metricbeat_doc['cluster_state']['master_node']
     metricbeat_doc['cluster_state']['master_node'] = new_node_name
@@ -26,7 +26,7 @@ def handle_special_case_cluster_stats(internal_doc, metricbeat_doc):
     del metricbeat_doc['cluster_state']['nodes'][orig_node_name]
 
     # When Metricbeat-based monitoring is used, Metricbeat will setup an ILM policy for
-    # metricbeat-* indices. Obviously this policy is not present when internal monitoring is
+    # metricbeat-* indices. Obviously this policy is not present when legacy monitoring is
     # used, since Metricbeat is not running in that case. So we normalize by removing the
     # usage stats associated with the Metricbeat-created ILM policy.
     policy_stats = metricbeat_doc["stack_stats"]["xpack"]["ilm"]["policy_stats"]
@@ -49,72 +49,72 @@ def handle_special_case_cluster_stats(internal_doc, metricbeat_doc):
     # The `_cluster/stats` api will return a `null` entry for this key if the license level
     # does not have a `max_resouce_units` which causes Metricbeat to strip it out
     # If that happens, just assume parity between the two
-    if 'max_resource_units' in internal_doc['license'] and internal_doc['license']['max_resource_units'] == None:
-      internal_doc['license'].pop('max_resource_units')
+    if 'max_resource_units' in legacy_doc['license'] and legacy_doc['license']['max_resource_units'] == None:
+      legacy_doc['license'].pop('max_resource_units')
 
 
     # The `field_types` field returns a list of what field types exist in all existing mappings
     # When running the parity tests, it is likely that the indices change between when we query
-    # internally collected documents versus when we query Metricbeat collected documents. These
+    # legacy collected documents versus when we query Metricbeat collected documents. These
     # two may or may not match as a result. 
-    # To get around this, we know that the parity tests query internally collected documents first
+    # To get around this, we know that the parity tests query legacy collected documents first
     # so we will ensure that all `field_types` that exist from that source also exist in the 
     # Metricbeat `field_types` (It is very likely the Metricbeat `field_types` will contain more)
-    internal_contains_all_in_metricbeat = True
-    if 'cluster_stats' in internal_doc:
-      for field_type in internal_doc["cluster_stats"]["indices"]["mappings"]["field_types"]:
-        internal_field_type_name = field_type["name"]
+    legacy_contains_all_in_metricbeat = True
+    if 'cluster_stats' in legacy_doc:
+      for field_type in legacy_doc["cluster_stats"]["indices"]["mappings"]["field_types"]:
+        legacy_field_type_name = field_type["name"]
         found = False
         for field_type in metricbeat_doc["cluster_stats"]["indices"]["mappings"]["field_types"]:
-          if field_type["name"] == internal_field_type_name:
+          if field_type["name"] == legacy_field_type_name:
             found = True
         
         if (not found):
-          internal_contains_all_in_metricbeat = False
+          legacy_contains_all_in_metricbeat = False
       
-      if internal_contains_all_in_metricbeat:
-        internal_doc["cluster_stats"]["indices"]["mappings"]["field_types"] = metricbeat_doc["cluster_stats"]["indices"]["mappings"]["field_types"]
+      if legacy_contains_all_in_metricbeat:
+        legacy_doc["cluster_stats"]["indices"]["mappings"]["field_types"] = metricbeat_doc["cluster_stats"]["indices"]["mappings"]["field_types"]
 
-def handle_special_case_node_stats(internal_doc, metricbeat_doc):
+def handle_special_case_node_stats(legacy_doc, metricbeat_doc):
     # Metricbeat-indexed docs of `type:node_stats` fake the `source_node` field since its required
     # by the UI. However, it only fakes the `source_node.uuid`, `source_node.name`, and
     # `source_node.transport_address` fields since those are the only ones actually used by
-    # the UI. So we normalize by removing all but those three fields from the internally-indexed
+    # the UI. So we normalize by removing all but those three fields from the legacy-indexed
     # doc.
-    source_node = internal_doc['source_node']
-    internal_doc['source_node'] = {
+    source_node = legacy_doc['source_node']
+    legacy_doc['source_node'] = {
       'uuid': source_node['uuid'],
       'name': source_node['name'],
       'transport_address': source_node['transport_address']
     }
 
-def handle_special_case_shards(internal_doc, metricbeat_doc):
+def handle_special_case_shards(legacy_doc, metricbeat_doc):
     # Metricbeat-indexed docs of `type:shard` fake the `source_node` field since its required
     # by the UI. However, it only fakes the `source_node.uuid` and `source_node.name` fields
     # since those are the only ones actually used by the UI. So we normalize by removing all
-    # but those two fields from the internally-indexed doc.
-    source_node = internal_doc['source_node']
-    internal_doc['source_node'] = {
+    # but those two fields from the legacy-indexed doc.
+    source_node = legacy_doc['source_node']
+    legacy_doc['source_node'] = {
       'uuid': source_node['uuid'],
       'name': source_node['name']
     }
 
-    # Internally-indexed docs of `type:shard` will set `shard.relocating_node` to `null`, if
+    # Legacy-indexed docs of `type:shard` will set `shard.relocating_node` to `null`, if
     # the shard is not relocating. However, Metricbeat-indexed docs of `type:shard` will simply
     # not send the `shard.relocating_node` field if the shard is not relocating. So we normalize
-    # by deleting the `shard.relocating_node` field from the internally-indexed doc if the shard
+    # by deleting the `shard.relocating_node` field from the legacy-indexed doc if the shard
     # is not relocating.
-    if 'relocating_node' in internal_doc['shard'] and internal_doc['shard']['relocating_node'] == None:
-        internal_doc['shard'].pop('relocating_node')
+    if 'relocating_node' in legacy_doc['shard'] and legacy_doc['shard']['relocating_node'] == None:
+        legacy_doc['shard'].pop('relocating_node')
 
-def handle_special_cases(doc_type, internal_doc, metricbeat_doc):
+def handle_special_cases(doc_type, legacy_doc, metricbeat_doc):
     if doc_type == "index_recovery":
-        handle_special_case_index_recovery(internal_doc, metricbeat_doc)
+        handle_special_case_index_recovery(legacy_doc, metricbeat_doc)
     if doc_type == "cluster_stats":
-        handle_special_case_cluster_stats(internal_doc, metricbeat_doc)
+        handle_special_case_cluster_stats(legacy_doc, metricbeat_doc)
     if doc_type == 'node_stats':
-        handle_special_case_node_stats(internal_doc, metricbeat_doc)
+        handle_special_case_node_stats(legacy_doc, metricbeat_doc)
     if doc_type == 'shards':
-        handle_special_case_shards(internal_doc, metricbeat_doc)
+        handle_special_case_shards(legacy_doc, metricbeat_doc)
 
 check_parity(handle_special_cases)

--- a/playbooks/monitoring/elasticsearch/docs_parity.yml
+++ b/playbooks/monitoring/elasticsearch/docs_parity.yml
@@ -1,5 +1,5 @@
 #----------------------------------------------------------------------------------------------------------------------
-# Playbook: Test for parity between metricbeat-indexes and internally-indexed Monitoring docs
+# Playbook: Test for parity between metricbeat-indexes and legacy-indexed Monitoring docs
 #
 # Author: shaunak@elastic.co
 #----------------------------------------------------------------------------------------------------------------------
@@ -53,7 +53,7 @@
         state: directory
         path: "{{ monitoring_docs_dir }}/elasticsearch/{{ item }}/"
       with_items:
-        - internal
+        - legacy
         - metricbeat
       delegate_to: localhost
 
@@ -63,7 +63,7 @@
       vars:
         ait_role: xpack_elasticsearch_install_gencert_config_start_verify
 
-    - name: Enable internal monitoring collection
+    - name: Enable legacy monitoring collection
       uri:
         method: PUT
         url: "https://{{ current_host_ip }}:{{ elasticsearch_port }}/_cluster/settings"
@@ -94,7 +94,7 @@
     - name: Write sample docs to temp files
       copy:
         content: "{{ item._source }}"
-        dest: "{{ monitoring_docs_dir }}/elasticsearch/internal/{{ item._source.type }}.json"
+        dest: "{{ monitoring_docs_dir }}/elasticsearch/legacy/{{ item._source.type }}.json"
       with_items: "{{ xpack_elasticsearch_monitoring_sample_docs.json.hits.hits }}"
       delegate_to: localhost
 
@@ -187,6 +187,6 @@
       vars:
         ait_action: elasticsearch_shutdown
 
-    - name: Compare internally-indexed and metricbeat-indexed documents for parity
-      shell: 'python {{ playbook_dir }}/docs_compare.py {{ monitoring_docs_dir }}/elasticsearch/internal {{ monitoring_docs_dir }}/elasticsearch/metricbeat'
+    - name: Compare legacy-indexed and metricbeat-indexed documents for parity
+      shell: 'python {{ playbook_dir }}/docs_compare.py {{ monitoring_docs_dir }}/elasticsearch/legacy {{ monitoring_docs_dir }}/elasticsearch/metricbeat'
       delegate_to: localhost

--- a/playbooks/monitoring/kibana/docs_compare.py
+++ b/playbooks/monitoring/kibana/docs_compare.py
@@ -1,6 +1,6 @@
 '''
 Usage:
-  python docs_compare.py /path/to/internal/docs /path/to/metricbeat/docs
+  python docs_compare.py /path/to/legacy/docs /path/to/metricbeat/docs
 '''
 
 from docs_compare_util import check_parity
@@ -11,18 +11,18 @@ allowed_deletions_from_metricbeat_docs_extra = [
   'kibana_stats.response_times.average'
 ]
 
-def handle_special_case_kibana_settings(internal_doc, metricbeat_doc):
-  # Internal collection will index kibana_settings.xpack.default_admin_email as null
+def handle_special_case_kibana_settings(legacy_doc, metricbeat_doc):
+  # Legacy collection will index kibana_settings.xpack.default_admin_email as null
   # whereas Metricbeat collection simply won't index it. So if we find kibana_settings.xpack.default_admin_email 
   # is null, we simply remove it
-  if "xpack" in internal_doc["kibana_settings"] \
-    and "default_admin_email" in internal_doc["kibana_settings"]["xpack"] \
-    and internal_doc["kibana_settings"]["xpack"]["default_admin_email"] == None:
-    internal_doc["kibana_settings"]["xpack"].pop("default_admin_email")
+  if "xpack" in legacy_doc["kibana_settings"] \
+    and "default_admin_email" in legacy_doc["kibana_settings"]["xpack"] \
+    and legacy_doc["kibana_settings"]["xpack"]["default_admin_email"] == None:
+    legacy_doc["kibana_settings"]["xpack"].pop("default_admin_email")
 
-def handle_special_cases(doc_type, internal_doc, metricbeat_doc):
+def handle_special_cases(doc_type, legacy_doc, metricbeat_doc):
     if doc_type == "kibana_settings":
-        handle_special_case_kibana_settings(internal_doc, metricbeat_doc)
+        handle_special_case_kibana_settings(legacy_doc, metricbeat_doc)
 
 
 check_parity(handle_special_cases, allowed_deletions_from_metricbeat_docs_extra=allowed_deletions_from_metricbeat_docs_extra)

--- a/playbooks/monitoring/kibana/docs_parity.yml
+++ b/playbooks/monitoring/kibana/docs_parity.yml
@@ -1,5 +1,5 @@
 #----------------------------------------------------------------------------------------------------------------------
-# Playbook: Test for parity between metricbeat-indexes and internally-indexed Monitoring docs
+# Playbook: Test for parity between metricbeat-indexes and legacy-indexed Monitoring docs
 #
 # Author: shaunak@elastic.co
 #----------------------------------------------------------------------------------------------------------------------
@@ -28,7 +28,7 @@
         state: directory
         path: "{{ monitoring_docs_dir }}/kibana/{{ item }}/"
       with_items:
-        - internal
+        - legacy
         - metricbeat
       delegate_to: localhost
 
@@ -71,11 +71,11 @@
     - name: Write sample docs to temp files
       copy:
         content: "{{ item._source }}"
-        dest: "{{ monitoring_docs_dir }}/kibana/internal/{{ item._source.type }}.json"
+        dest: "{{ monitoring_docs_dir }}/kibana/legacy/{{ item._source.type }}.json"
       with_items: "{{ xpack_elasticsearch_monitoring_sample_docs.json.hits.hits }}"
       delegate_to: localhost
 
-    - name: Stop kibana internal monitoring
+    - name: Stop kibana legacy monitoring
       include_role:
         name: xpack_kibana
       vars:
@@ -172,6 +172,6 @@
       vars:
         ait_action: elasticsearch_shutdown
 
-    - name: Compare internally-indexed and metricbeat-indexed documents for parity
-      shell: 'python {{ playbook_dir }}/docs_compare.py {{ monitoring_docs_dir }}/kibana/internal {{ monitoring_docs_dir }}/kibana/metricbeat'
+    - name: Compare legacy-indexed and metricbeat-indexed documents for parity
+      shell: 'python {{ playbook_dir }}/docs_compare.py {{ monitoring_docs_dir }}/kibana/legacy {{ monitoring_docs_dir }}/kibana/metricbeat'
       delegate_to: localhost

--- a/playbooks/monitoring/logstash/docs_compare.py
+++ b/playbooks/monitoring/logstash/docs_compare.py
@@ -1,17 +1,17 @@
 '''
 Usage:
-  python docs_compare.py /path/to/internal/docs /path/to/metricbeat/docs
+  python docs_compare.py /path/to/legacy/docs /path/to/metricbeat/docs
 '''
 
 from docs_compare_util import check_parity
 
-def handle_special_case_logstash_stats(internal_doc, metricbeat_doc):
+def handle_special_case_logstash_stats(legacy_doc, metricbeat_doc):
     # Normalize `logstash_stats.pipelines[0].vertices` array in both docs to be sorted by vertex ID
-    internal_doc["logstash_stats"]["pipelines"][0]["vertices"].sort(key=lambda pipeline: pipeline["id"])
+    legacy_doc["logstash_stats"]["pipelines"][0]["vertices"].sort(key=lambda pipeline: pipeline["id"])
     metricbeat_doc["logstash_stats"]["pipelines"][0]["vertices"].sort(key=lambda pipeline: pipeline["id"])
 
-def handle_special_cases(doc_type, internal_doc, metricbeat_doc):
+def handle_special_cases(doc_type, legacy_doc, metricbeat_doc):
     if doc_type == "logstash_stats":
-        handle_special_case_logstash_stats(internal_doc, metricbeat_doc)
+        handle_special_case_logstash_stats(legacy_doc, metricbeat_doc)
 
 check_parity(handle_special_cases)

--- a/playbooks/monitoring/logstash/docs_parity.yml
+++ b/playbooks/monitoring/logstash/docs_parity.yml
@@ -1,5 +1,5 @@
 #----------------------------------------------------------------------------------------------------------------------
-# Playbook: Test for parity between metricbeat-indexes and internally-indexed Monitoring docs
+# Playbook: Test for parity between metricbeat-indexes and legacy-indexed Monitoring docs
 #
 # Author: shaunak@elastic.co
 #----------------------------------------------------------------------------------------------------------------------
@@ -29,7 +29,7 @@
         state: directory
         path: "{{ monitoring_docs_dir }}/logstash/{{ item }}/"
       with_items:
-        - internal
+        - legacy
         - metricbeat
       delegate_to: localhost
 
@@ -72,7 +72,7 @@
     - name: Write sample docs to temp files
       copy:
         content: "{{ item._source }}"
-        dest: "{{ monitoring_docs_dir }}/logstash/internal/{{ item._source.type }}.json"
+        dest: "{{ monitoring_docs_dir }}/logstash/legacy/{{ item._source.type }}.json"
       with_items: "{{ xpack_elasticsearch_monitoring_sample_docs.json.hits.hits }}"
       delegate_to: localhost
 
@@ -166,6 +166,6 @@
       vars:
         ait_action: elasticsearch_shutdown
 
-    - name: Compare internally-indexed and metricbeat-indexed documents for parity
-      shell: 'python {{ playbook_dir }}/docs_compare.py {{ monitoring_docs_dir }}/logstash/internal {{ monitoring_docs_dir }}/logstash/metricbeat'
+    - name: Compare legacy-indexed and metricbeat-indexed documents for parity
+      shell: 'python {{ playbook_dir }}/docs_compare.py {{ monitoring_docs_dir }}/logstash/legacy {{ monitoring_docs_dir }}/logstash/metricbeat'
       delegate_to: localhost


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Replace references to "internal" with "legacy"  (#549)