### PR TITLE
[7.x] Fix build type (#776)

### DIFF
--- a/playbooks/stack_testing/ci/jenkins_stack_testing.sh
+++ b/playbooks/stack_testing/ci/jenkins_stack_testing.sh
@@ -6,5 +6,6 @@
 export AIT_ANSIBLE_PLAYBOOK="$(pwd)/playbooks/stack_testing/install_xpack.yml"
 export ES_BUILD_PKG_EXT=tar
 export AIT_VM=vagrant_vm
+export ES_BUILD_OSS=false
 
 source jenkins_build.sh


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Fix build type (#776)