### PR TITLE
Security Solution Upgrade testing Phase 4: Integrate the upgrade testing framework with Cypress

### DIFF
--- a/ci/kibana/jenkins_kibana_tests.sh
+++ b/ci/kibana/jenkins_kibana_tests.sh
@@ -3374,7 +3374,7 @@ case "$TEST_GROUP" in
     run_upgrade_tests
     ;;
   upgrade_security_solution)
-    run_upgrade_security_solution_tests
+    run_security_solution_upgrade_tests
     ;;
   selenium)
     run_basic_tests

--- a/ci/kibana/jenkins_kibana_tests.sh
+++ b/ci/kibana/jenkins_kibana_tests.sh
@@ -1836,6 +1836,47 @@ function run_upgrade_tests() {
 }
 
 # -----------------------------------------------------------------------------
+# Method to run security solution upgrade tests
+# -----------------------------------------------------------------------------
+function run_security_solution_upgrade_tests() {
+  echo_info "In run_security_solution_upgrade_tests"
+  local maxRuns="${ESTF_NUMBER_EXECUTIONS:-1}"
+
+  run_ci_setup
+  update_test_files
+
+  local _xpack_dir="$(cd x-pack; pwd)"
+  echo_info "-> XPACK_DIR ${_xpack_dir}"
+  cd "$_xpack_dir"
+
+  # To fix FTR ssl certificate issue: https://github.com/elastic/kibana/pull/73317
+  export TEST_CLOUD=1
+
+  nodeOpts=" "
+  if [ ! -z $NODE_TLS_REJECT_UNAUTHORIZED ] && [[ $NODE_TLS_REJECT_UNAUTHORIZED -eq 0 ]]; then
+    nodeOpts="--no-warnings "
+  fi
+
+  failures=0
+  for i in $(seq 1 1 $maxRuns); do
+    export ESTF_RUN_NUMBER=$i
+    update_report_name "test/security_solution_cypress/upgrade_config.ts"
+
+    echo_info " -> Running upgrade security solution tests, run $i of $maxRuns"
+    eval node $nodeOpts ../scripts/functional_test_runner \
+          --config test/security_solution_cypress/upgrade_config.ts \
+          --debug
+    if [ $? -ne 0 ]; then
+      failures=1
+    fi
+  done
+
+  run_ci_cleanup
+
+  exit_script $failures "Upgrade Security Solution Tests failed!"
+}
+
+# -----------------------------------------------------------------------------
 # Run with timeout
 # -----------------------------------------------------------------------------
 function run_with_timeout {
@@ -3331,6 +3372,9 @@ case "$TEST_GROUP" in
     ;;
   upgrade)
     run_upgrade_tests
+    ;;
+  upgrade_security_solution)
+    run_upgrade_security_solution_tests
     ;;
   selenium)
     run_basic_tests

--- a/ci/upgrade/buildSrc/src/main/resources/detectionRule.json
+++ b/ci/upgrade/buildSrc/src/main/resources/detectionRule.json
@@ -3,7 +3,7 @@
   "risk_score": 7,
   "description": "My description",
   "interval": "10s",
-  "name": "Rule Name",
+  "name": "Custom query rule for upgrade",
   "severity": "low",
   "type": "query",
   "from": "now-17520h",

--- a/ci/upgrade/ess/build.gradle
+++ b/ci/upgrade/ess/build.gradle
@@ -321,8 +321,8 @@ security_solution_upgrade_tests.dependsOn ess_disable_saml_login
 tasks.getByPath(':kibana:run_security_solution_tests').onlyIf {
     final_version_7_12_0_later >= 0
 }
-tasks.getByPath(':kibana:run_security_solution_tests')
-security_solution_upgrade_tests
+tasks.getByPath(':kibana:run_security_solution_tests').finalizedBy ess_shutdown_deployment
+security_solution_upgrade_tests.finalizedBy ess_shutdown_deployment
 
 
 

--- a/ci/upgrade/ess/build.gradle
+++ b/ci/upgrade/ess/build.gradle
@@ -110,6 +110,11 @@ task kibana_upgrade_tests {
     dependsOn tasks.getByPath(':kibana:run_kibana_tests')
 }
 
+task security_solution_upgrade_tests {
+    rootProject.ext.test_task = "${name}"
+    dependsOn tasks.getByPath(':kibana:run_security_solution_tests')
+}
+
 static def get_kibana_info(String url, String username, String password) {
     int max_retries = 10
     for (int retries = 0; ; retries++) {
@@ -311,3 +316,13 @@ tasks.getByPath(':kibana:run_kibana_tests').onlyIf {
 }
 tasks.getByPath(':kibana:run_kibana_tests').finalizedBy ess_shutdown_deployment
 kibana_upgrade_tests.finalizedBy ess_shutdown_deployment
+
+security_solution_upgrade_tests.dependsOn ess_disable_saml_login
+tasks.getByPath(':kibana:run_security_solution_tests').onlyIf {
+    final_version_7_12_0_later >= 0
+}
+tasks.getByPath(':kibana:run_security_solution_tests')
+security_solution_upgrade_tests
+
+
+

--- a/ci/upgrade/kibana/build.gradle
+++ b/ci/upgrade/kibana/build.gradle
@@ -168,3 +168,4 @@ task run_kibana_tests(dependsOn: get_kibana_commit) {
             }
         }
     }
+}

--- a/ci/upgrade/kibana/build.gradle
+++ b/ci/upgrade/kibana/build.gradle
@@ -121,4 +121,50 @@ task run_kibana_tests(dependsOn: get_kibana_commit) {
             throw new GradleException("Kibana Tests Failed!")
         }
     }
-}
+
+    task run_security_solution_tests(dependsOn: get_kibana_commit) {
+        doFirst {
+
+            println("******* SECTION: RUN SECURITY SOLUTION TESTS *******")
+
+            // Add system environment variables
+            def envList = []
+            System.getenv().each { key, value ->
+                envList.add(key + "=" + value)
+            }
+
+            def kibanaUri = new URI(rootProject.props.kibana_url)
+
+            // Add specific Kibana environment variables
+            envList.add("TEST_KIBANA_URL=" + rootProject.props.kibana_url)
+            envList.add("TEST_KIBANA_HOSTNAME=" + kibanaUri?.getHost())
+            envList.add("TEST_KIBANA_PROTOCOL=" + 'https')
+            envList.add("TEST_KIBANA_PORT=" + kibanaUri?.getPort())
+
+            envList.add("TEST_ES_URL=" + rootProject.props.elasticsearch_url)
+            envList.add("TEST_ES_USER=" + rootProject.props.es_username)
+            envList.add("TEST_ES_PASS=" + rootProject.props.es_password)
+
+            if (rootProject.hasProperty('tls_reject')) {
+                envList.add("NODE_TLS_REJECT_UNAUTHORIZED=0")
+                envList.add("TEST_IGNORE_CERT_ERRORS=1")
+            }
+
+            println "************"
+            println System.getenv()
+            println "************"
+
+            println "************"
+            println envList
+            println "************"
+
+            println "Running Kibana Tests...."
+            // Run Kibana tests
+            ShellCommand shell = new ShellCommand("./jenkins_kibana_tests.sh upgrade_security_solution", "$buildDir/kibana", envList)
+            shell.waitFor()
+
+            if (shell.getRc() != 0) {
+                throw new GradleException("Kibana Security Solution Tests Failed!")
+            }
+        }
+    }

--- a/ci/upgrade/kibana/build.gradle
+++ b/ci/upgrade/kibana/build.gradle
@@ -121,51 +121,51 @@ task run_kibana_tests(dependsOn: get_kibana_commit) {
             throw new GradleException("Kibana Tests Failed!")
         }
     }
+}
 
-    task run_security_solution_tests(dependsOn: get_kibana_commit) {
-        doFirst {
+task run_security_solution_tests(dependsOn: get_kibana_commit) {
+    doFirst {
 
-            println("******* SECTION: RUN SECURITY SOLUTION TESTS *******")
+        println("******* SECTION: RUN SECURITY SOLUTION TESTS *******")
 
-            // Add system environment variables
-            def envList = []
-            System.getenv().each { key, value ->
-                envList.add(key + "=" + value)
-            }
+        // Add system environment variables
+        def envList = []
+        System.getenv().each { key, value ->
+            envList.add(key + "=" + value)
+        }
 
-            def kibanaUri = new URI(rootProject.props.kibana_url)
+        def kibanaUri = new URI(rootProject.props.kibana_url)
 
-            // Add specific Kibana environment variables
-            envList.add("TEST_KIBANA_URL=" + rootProject.props.kibana_url)
-            envList.add("TEST_KIBANA_HOSTNAME=" + kibanaUri?.getHost())
-            envList.add("TEST_KIBANA_PROTOCOL=" + 'https')
-            envList.add("TEST_KIBANA_PORT=" + kibanaUri?.getPort())
+        // Add specific Kibana environment variables
+        envList.add("TEST_KIBANA_URL=" + rootProject.props.kibana_url)
+        envList.add("TEST_KIBANA_HOSTNAME=" + kibanaUri?.getHost())
+        envList.add("TEST_KIBANA_PROTOCOL=" + 'https')
+        envList.add("TEST_KIBANA_PORT=" + kibanaUri?.getPort())
 
-            envList.add("TEST_ES_URL=" + rootProject.props.elasticsearch_url)
-            envList.add("TEST_ES_USER=" + rootProject.props.es_username)
-            envList.add("TEST_ES_PASS=" + rootProject.props.es_password)
+        envList.add("TEST_ES_URL=" + rootProject.props.elasticsearch_url)
+        envList.add("TEST_ES_USER=" + rootProject.props.es_username)
+        envList.add("TEST_ES_PASS=" + rootProject.props.es_password)
 
-            if (rootProject.hasProperty('tls_reject')) {
-                envList.add("NODE_TLS_REJECT_UNAUTHORIZED=0")
-                envList.add("TEST_IGNORE_CERT_ERRORS=1")
-            }
+        if (rootProject.hasProperty('tls_reject')) {
+            envList.add("NODE_TLS_REJECT_UNAUTHORIZED=0")
+            envList.add("TEST_IGNORE_CERT_ERRORS=1")
+        }
 
-            println "************"
-            println System.getenv()
-            println "************"
+        println "************"
+        println System.getenv()
+        println "************"
 
-            println "************"
-            println envList
-            println "************"
+        println "************"
+        println envList
+        println "************"
 
-            println "Running Kibana Tests...."
-            // Run Kibana tests
-            ShellCommand shell = new ShellCommand("./jenkins_kibana_tests.sh upgrade_security_solution", "$buildDir/kibana", envList)
-            shell.waitFor()
+        println "Running Kibana Tests...."
+        // Run Kibana tests
+        ShellCommand shell = new ShellCommand("./jenkins_kibana_tests.sh upgrade_security_solution", "$buildDir/kibana", envList)
+        shell.waitFor()
 
-            if (shell.getRc() != 0) {
-                throw new GradleException("Kibana Security Solution Tests Failed!")
-            }
+        if (shell.getRc() != 0) {
+            throw new GradleException("Kibana Security Solution Tests Failed!")
         }
     }
 }


### PR DESCRIPTION
Following the issue https://github.com/elastic/elastic-stack-testing/issues/932 we are integrating the upgrade framework with the Security Solution Cypress tests.

In order to do that:
- We have created a new gradle task called `run_security_solution_tests` that task is setting the environment variables the Cypress test is going to use for the runner (https://github.com/elastic/kibana/blob/80ab2ff36de6554bd8a5f3a62bc18b971ea057a6/x-pack/test/security_solution_cypress/runner.ts#L153) and is calling the method that is going to actually execute the tests.
- We are extending the `jenkins_kibana_tests.sh` to execute the Cypress tests.

 