### PR TITLE
increase timeout for metricbeat to index documents

### DIFF
--- a/playbooks/monitoring/kibana/docs_parity.yml
+++ b/playbooks/monitoring/kibana/docs_parity.yml
@@ -141,7 +141,7 @@
 
     - name: Wait for metricbeat to index a few monitoring documents
       wait_for:
-        timeout: 15
+        timeout: 25
 
     - name: Stop metricbeat
       include_role:


### PR DESCRIPTION
https://github.com/elastic/elastic-stack-testing/issues/936

Parity tests when comparing the document count for legacy vs metricbeat indices is sometimes failing with:

```
04:26:10 TASK [Compare legacy-indexed and metricbeat-indexed documents for parity] ******
04:26:10 fatal: [aithost]: FAILED! => {
04:26:10     "changed": true,
04:26:10     "cmd": "python /var/lib/jenkins/workspace/elastic+estf-monitoring-snapshots+7.14+multijob-kibana/playbooks/monitoring/kibana/docs_compare.py /var/lib/jenkins/workspace/elastic+estf-monitoring-snapshots+7.14+multijob-kibana/monitoring//kibana/legacy /var/lib/jenkins/workspace/elastic+estf-monitoring-snapshots+7.14+multijob-kibana/monitoring//kibana/metricbeat",
04:26:10     "delta": "0:00:00.106392",
04:26:10     "end": "2021-07-13 12:24:57.553722",
04:26:10     "rc": 1,
04:26:10     "start": "2021-07-13 12:24:57.447330"
04:26:10 }
04:26:10 
04:26:10 STDERR:
04:26:10 
04:26:10 ERROR: Found more legacy-indexed document types than metricbeat-indexed document types.
04:26:10                Document types indexed by legacy collection but not by Metricbeat collection: {'kibana_stats', 'kibana_settings'}
04:26:10 Traceback (most recent call last):
04:26:10   File "/var/lib/jenkins/workspace/elastic+estf-monitoring-snapshots+7.14+multijob-kibana/playbooks/monitoring/kibana/docs_compare.py", line 49, in <module>
04:26:10     check_parity(handle_special_cases, allowed_deletions_from_metricbeat_docs_extra=allowed_deletions_from_metricbeat_docs_extra)
04:26:10   File "/var/lib/jenkins/workspace/elastic+estf-monitoring-snapshots+7.14+multijob-kibana/playbooks/monitoring/common/docs_compare_util.py", line 162, in check_parity
04:26:10     metricbeat_doc = get_doc(metricbeat_docs_path, doc_type)
04:26:10   File "/var/lib/jenkins/workspace/elastic+estf-monitoring-snapshots+7.14+multijob-kibana/playbooks/monitoring/common/docs_compare_util.py", line 66, in get_doc
04:26:10     with open(os.path.join(docs_path, doc_type + ".json")) as f:
04:26:10 FileNotFoundError: [Errno 2] No such file or directory: '/var/lib/jenkins/workspace/elastic+estf-monitoring-snapshots+7.14+multijob-kibana/monitoring//kibana/metricbeat/kibana_stats.json'

```

This PR increases the timeout for metricbeat to index documents as it seems this is probably a timing issue.