### PR TITLE
[7.x] increase timeout for metricbeat to index (#962)

### DIFF
--- a/playbooks/monitoring/kibana/docs_parity.yml
+++ b/playbooks/monitoring/kibana/docs_parity.yml
@@ -141,7 +141,7 @@
 
     - name: Wait for metricbeat to index a few monitoring documents
       wait_for:
-        timeout: 15
+        timeout: 25
 
     - name: Stop metricbeat
       include_role:


### PR DESCRIPTION
Backports the following commits to 7.x:
 - increase timeout for metricbeat to index (#962)