### PR TITLE
retry metricbeat doc request 5 times

### DIFF
--- a/playbooks/monitoring/kibana/docs_parity.yml
+++ b/playbooks/monitoring/kibana/docs_parity.yml
@@ -141,19 +141,7 @@
 
     - name: Wait for metricbeat to index a few monitoring documents
       wait_for:
-        timeout: 25
-
-    - name: Stop metricbeat
-      include_role:
-        name: metricbeat
-      vars:
-        ait_action: metricbeat_shutdown
-
-    - name: Stop kibana
-      include_role:
-        name: kibana
-      vars:
-        ait_role: kibana_shutdown_verify
+        timeout: 15
 
     - name: Get sample metricbeat-indexed docs from monitoring index
       uri:
@@ -166,14 +154,29 @@
         body: '{ "collapse": { "field": "type" }, "sort": { "timestamp": "asc" } }'
         body_format: json
         status_code: 200
+      until: xpack_elasticsearch_monitoring_sample_docs.json.hits.total.value > 0
+      retries: 5
+      delay: 10
       register: xpack_elasticsearch_monitoring_sample_docs
-
+    
     - name: Write sample docs to temp files
       copy:
         content: "{{ item._source }}"
         dest: "{{ monitoring_docs_dir }}/kibana/metricbeat/{{ item._source.type }}.json"
       with_items: "{{ xpack_elasticsearch_monitoring_sample_docs.json.hits.hits }}"
       delegate_to: localhost
+    
+    - name: Stop metricbeat
+      include_role:
+        name: metricbeat
+      vars:
+        ait_action: metricbeat_shutdown
+
+    - name: Stop kibana
+      include_role:
+        name: kibana
+      vars:
+        ait_role: kibana_shutdown_verify
 
     - name: Stop elasticsearch
       include_role:


### PR DESCRIPTION
https://github.com/elastic/elastic-stack-testing/issues/936

Parity tests when comparing the document count for legacy vs metricbeat indices is sometimes failing with:

```
04:26:10 TASK [Compare legacy-indexed and metricbeat-indexed documents for parity] ******
04:26:10 fatal: [aithost]: FAILED! => {
04:26:10     "changed": true,
04:26:10     "cmd": "python /var/lib/jenkins/workspace/elastic+estf-monitoring-snapshots+7.14+multijob-kibana/playbooks/monitoring/kibana/docs_compare.py /var/lib/jenkins/workspace/elastic+estf-monitoring-snapshots+7.14+multijob-kibana/monitoring//kibana/legacy /var/lib/jenkins/workspace/elastic+estf-monitoring-snapshots+7.14+multijob-kibana/monitoring//kibana/metricbeat",
04:26:10     "delta": "0:00:00.106392",
04:26:10     "end": "2021-07-13 12:24:57.553722",
04:26:10     "rc": 1,
04:26:10     "start": "2021-07-13 12:24:57.447330"
04:26:10 }
04:26:10 
04:26:10 STDERR:
04:26:10 
04:26:10 ERROR: Found more legacy-indexed document types than metricbeat-indexed document types.
04:26:10                Document types indexed by legacy collection but not by Metricbeat collection: {'kibana_stats', 'kibana_settings'}
04:26:10 Traceback (most recent call last):
04:26:10   File "/var/lib/jenkins/workspace/elastic+estf-monitoring-snapshots+7.14+multijob-kibana/playbooks/monitoring/kibana/docs_compare.py", line 49, in <module>
04:26:10     check_parity(handle_special_cases, allowed_deletions_from_metricbeat_docs_extra=allowed_deletions_from_metricbeat_docs_extra)
04:26:10   File "/var/lib/jenkins/workspace/elastic+estf-monitoring-snapshots+7.14+multijob-kibana/playbooks/monitoring/common/docs_compare_util.py", line 162, in check_parity
04:26:10     metricbeat_doc = get_doc(metricbeat_docs_path, doc_type)
04:26:10   File "/var/lib/jenkins/workspace/elastic+estf-monitoring-snapshots+7.14+multijob-kibana/playbooks/monitoring/common/docs_compare_util.py", line 66, in get_doc
04:26:10     with open(os.path.join(docs_path, doc_type + ".json")) as f:
04:26:10 FileNotFoundError: [Errno 2] No such file or directory: '/var/lib/jenkins/workspace/elastic+estf-monitoring-snapshots+7.14+multijob-kibana/monitoring//kibana/metricbeat/kibana_stats.json'

```

After https://github.com/elastic/elastic-stack-testing/pull/962 did not solve the issue, this PR moves stopping metricbeat and kibana until after we try to request docs and retry the request 5 times if none exist.  