### PR TITLE
[Security Solution] Creates siem signals index when needed

### DIFF
--- a/ci/upgrade/buildSrc/src/main/java/org/estf/gradle/UploadSecuritySolutionData.java
+++ b/ci/upgrade/buildSrc/src/main/java/org/estf/gradle/UploadSecuritySolutionData.java
@@ -40,12 +40,15 @@ public class UploadSecuritySolutionData extends DefaultTask {
         RestApi api = new RestApi(username, password, version, upgradeVersion);
         Instance instance = new Instance(username, password, esBaseUrl, kbnBaseUrl);
         Version versionThresholdExist = new Version("7.10");
+        Version alertsIndexVersion = new Version("8.0")
         Version instanceVersion = new Version(version);
 
         int majorVersion = api.setMajorVersion();
         if (majorVersion > 6) {
             //General setup
-            createsSiemSignalsIndex(instance);
+            if(!instanceVersion.newestOrEqualThan(alertsIndexVersion)) {
+                createsSiemSignalsIndex(instance);
+            }
 
             //Custom query detection rule setup
             createsAuditbeatCustomIndex(instance);


### PR DESCRIPTION
Starting 8.0 we are not going to store the alerts generated on the .siem-signals index, we are going to do it on the new alerts index.

Prior 8.0, we need to have the .siem-signals created in order to be able to create a rule, that is a limitation not happening any more in new releases. Now the new alerts index is automatically generated when the first alert is created.

In this PR we are accommodating the data generation to this new behaviour. We check if we are on a version prior 8.0, if so we create the .siem-signals index, if not, we don't create the index and we proceed with the rest of the data genearion.