### PR TITLE
Breakup upgrade jobs

### DIFF
--- a/ci/upgrade/jobs/ess_upgrade_jobs.yml
+++ b/ci/upgrade/jobs/ess_upgrade_jobs.yml
@@ -1,20 +1,34 @@
 TASK:
   - kibana_upgrade_tests
 JOB:
-    - upgradeTest4a
-    - upgradeTest4b
-    - upgradeTest4c
-    - upgradeTest4d
-    - upgradeTest4e
-    - upgradeTest4f
-    - upgradeTest4g
-    - upgradeTest4h
-    - upgradeTest4i
-    - upgradeTest4j
-    - upgradeTest4k
-    - upgradeTest4l
-    - upgradeTest4m
-    - upgradeTest4n
-    - upgradeTest4o
+  - upgradeTest1a
+  - upgradeTest1b
+  - upgradeTest1c
+  - upgradeTest1d
+  - upgradeTest1e
+  - upgradeTest1f
+  - upgradeTest1g
+  - upgradeTest1h
+  - upgradeTest1i
+  - upgradeTest1j
+  - upgradeTest1k
+  - upgradeTest1l
+  - upgradeTest2a
+  - upgradeTest2b
+  - upgradeTest2c
+  - upgradeTest2d
+  - upgradeTest2e
+  - upgradeTest2f
+  - upgradeTest2g
+  - upgradeTest2h
+  - upgradeTest2i
+  - upgradeTest2j
+  - upgradeTest2k
+  - upgradeTest2l
+  - upgradeTest2m
+  - upgradeTest2n
+  - upgradeTest2o
+  - upgradeTest2p
+  - upgradeTest21
 
 exclude: ~

--- a/ci/upgrade/jobs/ess_upgrade_jobs_7_17.yml
+++ b/ci/upgrade/jobs/ess_upgrade_jobs_7_17.yml
@@ -1,0 +1,15 @@
+TASK:
+  - kibana_upgrade_tests
+JOB:
+    - upgradeTest3a
+    - upgradeTest3b
+    - upgradeTest3c
+    - upgradeTest3d
+    - upgradeTest3e
+    - upgradeTest3f
+    - upgradeTest3g
+    - upgradeTest3h
+    - upgradeTest3i
+    - upgradeTest3j
+
+exclude: ~

--- a/ci/upgrade/jobs/ess_upgrade_jobs_8_2.yml
+++ b/ci/upgrade/jobs/ess_upgrade_jobs_8_2.yml
@@ -1,0 +1,20 @@
+TASK:
+  - kibana_upgrade_tests
+JOB:
+    - upgradeTest4a
+    - upgradeTest4b
+    - upgradeTest4c
+    - upgradeTest4d
+    - upgradeTest4e
+    - upgradeTest4f
+    - upgradeTest4g
+    - upgradeTest4h
+    - upgradeTest4i
+    - upgradeTest4j
+    - upgradeTest4k
+    - upgradeTest4l
+    - upgradeTest4m
+    - upgradeTest4n
+    - upgradeTest4o
+
+exclude: ~

--- a/ci/upgrade/jobs/ess_upgrade_jobs_8_3.yml
+++ b/ci/upgrade/jobs/ess_upgrade_jobs_8_3.yml
@@ -1,0 +1,20 @@
+TASK:
+  - kibana_upgrade_tests
+JOB:
+    - upgradeTest5a
+    - upgradeTest5b
+    - upgradeTest5c
+    - upgradeTest5d
+    - upgradeTest5e
+    - upgradeTest5f
+    - upgradeTest5g
+    - upgradeTest5h
+    - upgradeTest5i
+    - upgradeTest5j
+    - upgradeTest5k
+    - upgradeTest5l
+    - upgradeTest5m
+    - upgradeTest5n
+    - upgradeTest5o
+
+exclude: ~


### PR DESCRIPTION
Try splitting up jobs for Jenkins by releases and snapshots by version.  This could then be setup to be triggered by RM instead of timer.  Jenkins jobs pending.